### PR TITLE
Add Korean translation of agents tutorial notebook

### DIFF
--- a/docs/docs/tutorials/agents_ko.ipynb
+++ b/docs/docs/tutorials/agents_ko.ipynb
@@ -1,0 +1,837 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "17546ebb",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "---\n",
+    "keywords: [agent, agents]\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1df78a71",
+   "metadata": {},
+   "source": [
+    "# 에이전트를 구축하십시오\n",
+    "\n",
+    "Langchain은 [에이전트] (/docs/concepts/agents) 또는 [LLMS] (/docs/concepts/chat_models)를 사용하는 시스템의 생성을 지원하여 엔진을 추론하여 동작을 수행하는 데 필요한 작업 및 입력을 결정합니다.\n",
+    "작업을 실행 한 후 결과를 LLM으로 Fed Back으로 공급하여 더 많은 작업이 필요한지 또는 완료하는 것이 괜찮은지 여부를 결정할 수 있습니다.이것은 종종 [Tool-Calling] (/docs/concepts/tool_calling)를 통해 달성됩니다.\n",
+    "\n",
+    "이 튜토리얼에서는 검색 엔진과 상호 작용할 수있는 에이전트를 구축합니다.이 에이전트 질문을하고 검색 도구에 전화를 걸고 대화를 할 수 있습니다.\n",
+    "\n",
+    "## 엔드 투 엔드 에이전트\n",
+    "\n",
+    "아래 코드 스 니펫은 LLM을 사용하여 사용할 도구를 결정하는 완벽한 기능 에이전트를 나타냅니다.일반 검색 도구가 장착되어 있습니다.대화 메모리가 있습니다. 즉, 다중 전환 챗봇으로 사용할 수 있음을 의미합니다.\n",
+    "\n",
+    "가이드의 나머지 부분에서는 개별 구성 요소와 각 부분이하는 일을 안내하지만 코드를 잡고 시작하려면 자유롭게 사용하십시오!\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "86d9386b-442f-4cd6-a78f-57c88249d3f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import relevant functionality\n",
+    "from langchain.chat_models import init_chat_model\n",
+    "from langchain_tavily import TavilySearch\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
+    "from langgraph.prebuilt import create_react_agent\n",
+    "\n",
+    "# Create the agent\n",
+    "memory = MemorySaver()\n",
+    "model = init_chat_model(\"anthropic:claude-3-5-sonnet-latest\")\n",
+    "search = TavilySearch(max_results=2)\n",
+    "tools = [search]\n",
+    "agent_executor = create_react_agent(model, tools, checkpointer=memory)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7ab50503-d09f-4ff4-9080-5afe297ccc38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Hi, I'm Bob and I live in SF.\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Hello Bob! I notice you've introduced yourself and mentioned you live in SF (San Francisco), but you haven't asked a specific question or made a request that requires the use of any tools. Is there something specific you'd like to know about San Francisco or any other topic? I'd be happy to help you find information using the available search tools.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Use the agent\n",
+    "config = {\"configurable\": {\"thread_id\": \"abc123\"}}\n",
+    "\n",
+    "input_message = {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": \"Hi, I'm Bob and I live in SF.\",\n",
+    "}\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fcadb699-3787-4028-a5f6-e5605c8118d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What's the weather where I live?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "[{'text': 'Let me search for current weather information in San Francisco.', 'type': 'text'}, {'id': 'toolu_011kSdheoJp8THURoLmeLtZo', 'input': {'query': 'current weather San Francisco CA'}, 'name': 'tavily_search', 'type': 'tool_use'}]\n",
+      "Tool Calls:\n",
+      "  tavily_search (toolu_011kSdheoJp8THURoLmeLtZo)\n",
+      " Call ID: toolu_011kSdheoJp8THURoLmeLtZo\n",
+      "  Args:\n",
+      "    query: current weather San Francisco CA\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: tavily_search\n",
+      "\n",
+      "{\"query\": \"current weather San Francisco CA\", \"follow_up_questions\": null, \"answer\": null, \"images\": [], \"results\": [{\"title\": \"Weather in San Francisco, CA\", \"url\": \"https://www.weatherapi.com/\", \"content\": \"{'location': {'name': 'San Francisco', 'region': 'California', 'country': 'United States of America', 'lat': 37.775, 'lon': -122.4183, 'tz_id': 'America/Los_Angeles', 'localtime_epoch': 1750168606, 'localtime': '2025-06-17 06:56'}, 'current': {'last_updated_epoch': 1750167900, 'last_updated': '2025-06-17 06:45', 'temp_c': 11.7, 'temp_f': 53.1, 'is_day': 1, 'condition': {'text': 'Fog', 'icon': '//cdn.weatherapi.com/weather/64x64/day/248.png', 'code': 1135}, 'wind_mph': 4.0, 'wind_kph': 6.5, 'wind_degree': 215, 'wind_dir': 'SW', 'pressure_mb': 1017.0, 'pressure_in': 30.02, 'precip_mm': 0.0, 'precip_in': 0.0, 'humidity': 86, 'cloud': 0, 'feelslike_c': 11.3, 'feelslike_f': 52.4, 'windchill_c': 8.7, 'windchill_f': 47.7, 'heatindex_c': 9.8, 'heatindex_f': 49.7, 'dewpoint_c': 9.6, 'dewpoint_f': 49.2, 'vis_km': 16.0, 'vis_miles': 9.0, 'uv': 0.0, 'gust_mph': 6.3, 'gust_kph': 10.2}}\", \"score\": 0.944705, \"raw_content\": null}, {\"title\": \"Weather in San Francisco in June 2025\", \"url\": \"https://world-weather.info/forecast/usa/san_francisco/june-2025/\", \"content\": \"Detailed ⚡ San Francisco Weather Forecast for June 2025 - day/night 🌡️ temperatures, precipitations - World-Weather.info. Add the current city. Search. Weather; Archive; Weather Widget °F. World; United States; California; Weather in San Francisco; ... 17 +64° +54° 18 +61° +54° 19\", \"score\": 0.86441374, \"raw_content\": null}], \"response_time\": 2.34}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Based on the search results, here's the current weather in San Francisco:\n",
+      "- Temperature: 53.1°F (11.7°C)\n",
+      "- Condition: Foggy\n",
+      "- Wind: 4.0 mph from the Southwest\n",
+      "- Humidity: 86%\n",
+      "- Visibility: 9 miles\n",
+      "\n",
+      "This is quite typical weather for San Francisco, with the characteristic fog that the city is known for. Would you like to know anything else about the weather or San Francisco in general?\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": \"What's the weather where I live?\",\n",
+    "}\n",
+    "\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4c03f40-1328-412d-8a48-1db0cd481b77",
+   "metadata": {},
+   "source": [
+    "## 설정\n",
+    "\n",
+    "### Jupyter 노트\n",
+    "\n",
+    "이 안내서 (및 문서의 다른 가이드 대부분)는 [Jupyter Notebooks] (https://jupyter.org/)를 사용하고 독자도 마찬가지라고 가정합니다.Jupyter 노트북은 LLM 시스템을 사용하는 방법을 배우기위한 완벽한 대화식 환경입니다. 왜냐하면 종종 일이 잘못 될 수 있기 때문에 (예기치 않은 출력, API 다운 등), 이러한 사례를 관찰하는 것은 LLM으로 건축을 더 잘 이해하는 좋은 방법입니다.\n",
+    "\n",
+    "이 튜토리얼과 다른 튜토리얼은 아마도 Jupyter 노트북에서 가장 편리하게 실행됩니다.설치 방법에 대한 지침은 [여기] (https://jupyter.org/install)을 참조하십시오.\n",
+    "\n",
+    "### 설치\n",
+    "\n",
+    "Langchain Run을 설치하려면 :\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60bb3eb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -U langgraph langchain-tavily langgraph-checkpoint-sqlite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ee337ae",
+   "metadata": {},
+   "source": [
+    "자세한 내용은 [설치 안내서] (/docs/how_to/installation)를 참조하십시오.\n",
+    "\n",
+    "### Langsmith\n",
+    "\n",
+    "Langchain으로 구축 한 많은 응용 프로그램에는 LLM 통화가 여러 번 발생하여 여러 단계가 포함됩니다.\n",
+    "이러한 응용 프로그램이 점점 더 복잡해지면 체인이나 에이전트 내에서 정확히 무슨 일이 일어나고 있는지 검사하는 것이 중요합니다.\n",
+    "이를 수행하는 가장 좋은 방법은 [langsmith] (https://smith.langchain.com)입니다.\n",
+    "\n",
+    "위의 링크에 가입 한 후에는 환경 변수를 로깅 추적을 시작하도록 설정하십시오.\n",
+    "\n",
+    "```쉘\n",
+    "내보내기 langsmith_tracing = \"true\"\n",
+    "내보내기 langsmith_api_key = \"...\"\n",
+    "```\n",
+    "\n",
+    "또는 노트북에 있으면 다음과 같이 설정할 수 있습니다.\n",
+    "\n",
+    "```Python\n",
+    "getpass 가져 오기\n",
+    "OS 가져 오기\n",
+    "\n",
+    "os.environ [ \"langsmith_tracing\"] = \"true\"\n",
+    "os.environ [ \"langsmith_api_key\"] = getpass.getpass ()\n",
+    "```\n",
+    "\n",
+    "### tavily\n",
+    "\n",
+    "우리는 [tavily] (/docs/integrations/tools/tavily_search) (검색 엔진)을 도구로 사용할 것입니다.\n",
+    "이를 사용하려면 API 키를 가져 와서 설정해야합니다.\n",
+    "\n",
+    "```Bash\n",
+    "tavily_api_key = \"...\"내보내기\n",
+    "```\n",
+    "\n",
+    "또는 노트북에 있으면 다음과 같이 설정할 수 있습니다.\n",
+    "\n",
+    "```Python\n",
+    "getpass 가져 오기\n",
+    "OS 가져 오기\n",
+    "\n",
+    "os.environ [ \"tavily_api_key\"] = getpass.getpass ()\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c335d1bf",
+   "metadata": {},
+   "source": [
+    "## 도구 정의\n",
+    "\n",
+    "먼저 사용하려는 도구를 만들어야합니다.우리의 주요 선택 도구는 검색 엔진 인 [tavily] (/docs/integrations/tools/tavily_search)입니다.우리는 전용 [langchain-tavily] (https://pypi.org/project/langchain-tavily/) [통합 패키지] (/docs/concepts/architecture/#통합-패키지)을 Langchain과 함께 도구로 쉽게 사용할 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "76a02d36-6ea2-4e62-88b4-6c480dd9c04f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'query': 'What is the weather in SF', 'follow_up_questions': None, 'answer': None, 'images': [], 'results': [{'title': 'Weather in San Francisco, CA', 'url': 'https://www.weatherapi.com/', 'content': \"{'location': {'name': 'San Francisco', 'region': 'California', 'country': 'United States of America', 'lat': 37.775, 'lon': -122.4183, 'tz_id': 'America/Los_Angeles', 'localtime_epoch': 1750168606, 'localtime': '2025-06-17 06:56'}, 'current': {'last_updated_epoch': 1750167900, 'last_updated': '2025-06-17 06:45', 'temp_c': 11.7, 'temp_f': 53.1, 'is_day': 1, 'condition': {'text': 'Fog', 'icon': '//cdn.weatherapi.com/weather/64x64/day/248.png', 'code': 1135}, 'wind_mph': 4.0, 'wind_kph': 6.5, 'wind_degree': 215, 'wind_dir': 'SW', 'pressure_mb': 1017.0, 'pressure_in': 30.02, 'precip_mm': 0.0, 'precip_in': 0.0, 'humidity': 86, 'cloud': 0, 'feelslike_c': 11.3, 'feelslike_f': 52.4, 'windchill_c': 8.7, 'windchill_f': 47.7, 'heatindex_c': 9.8, 'heatindex_f': 49.7, 'dewpoint_c': 9.6, 'dewpoint_f': 49.2, 'vis_km': 16.0, 'vis_miles': 9.0, 'uv': 0.0, 'gust_mph': 6.3, 'gust_kph': 10.2}}\", 'score': 0.9185379, 'raw_content': None}, {'title': 'Weather in San Francisco in June 2025', 'url': 'https://world-weather.info/forecast/usa/san_francisco/june-2025/', 'content': \"Weather in San Francisco in June 2025 (California) - Detailed Weather Forecast for a Month *   Weather in San Francisco Weather in San Francisco in June 2025 *   1 +63° +55° *   2 +66° +54° *   3 +66° +55° *   4 +66° +54° *   5 +66° +55° *   6 +66° +57° *   7 +64° +55° *   8 +63° +55° *   9 +63° +54° *   10 +59° +54° *   11 +59° +54° *   12 +61° +54° Weather in Washington, D.C.**+68°** Sacramento**+81°** Pleasanton**+72°** Redwood City**+68°** San Leandro**+61°** San Mateo**+64°** San Rafael**+70°** San Ramon**+64°** South San Francisco**+61°** Daly City**+59°** Wilder**+66°** Woodacre**+70°** world's temperature today Colchani day+50°F night+16°F Az Zubayr day+124°F night+93°F Weather forecast on your site Install _San Francisco_ +61° Temperature units\", 'score': 0.7978881, 'raw_content': None}], 'response_time': 2.62}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_tavily import TavilySearch\n",
+    "\n",
+    "search = TavilySearch(max_results=2)\n",
+    "search_results = search.invoke(\"What is the weather in SF\")\n",
+    "print(search_results)\n",
+    "# If we want, we can create other tools.\n",
+    "# Once we have all the tools we want, we can put them in a list that we will reference later.\n",
+    "tools = [search]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecbc86d8",
+   "metadata": {},
+   "source": [
+    ":::팁\n",
+    "\n",
+    "많은 응용 분야에서 사용자 정의 도구를 정의 할 수 있습니다.Langchain은 관습을 지원합니다\n",
+    "파이썬 기능 및 기타 수단을 통한 도구 생성.참조\n",
+    "[도구를 만드는 방법] (/docs/how_to/custom_tools/) 자세한 내용은 안내서.\n",
+    "\n",
+    ":::\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e00068b0",
+   "metadata": {},
+   "source": [
+    "## 언어 모델 사용\n",
+    "\n",
+    "다음으로 언어 모델을 사용하여 도구를 호출하는 방법을 배우겠습니다.Langchain은 상호 교환 할 수있는 다양한 언어 모델을 지원합니다. 아래에서 사용할 것을 선택하십시오!\n",
+    "\n",
+    "\"@테마/chatmodeltabs\"에서 chatmodeltabs 가져 오기;\n",
+    "\n",
+    "<chatmodeltabs atedrideparams = {{openai : {model : \"gpt-4.1\"}} />\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "69185491",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# | output: false\n",
+    "# | echo: false\n",
+    "\n",
+    "from langchain_anthropic import ChatAnthropic\n",
+    "\n",
+    "model = ChatAnthropic(model=\"claude-3-5-sonnet-latest\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "642ed8bf",
+   "metadata": {},
+   "source": [
+    "메시지 목록을 전달하여 언어 모델을 호출 할 수 있습니다.기본적으로 응답은 'content'문자열입니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c96c960b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hello! How can I help you today?'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"Hi!\"\n",
+    "response = model.invoke([{\"role\": \"user\", \"content\": query}])\n",
+    "response.text()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47bf8210",
+   "metadata": {},
+   "source": [
+    "이제이 모델이 도구 호출을 수행 할 수 있도록하는 것이 어떤지 확인할 수 있습니다.우리가`.bind_tools`를 사용하여 이러한 도구에 대한 언어 모델 지식을 제공 할 수 있도록\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ba692a74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_with_tools = model.bind_tools(tools)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd920b69",
+   "metadata": {},
+   "source": [
+    "이제 모델을 호출 할 수 있습니다.먼저 일반 메시지로 전화하여 어떻게 응답하는지 살펴 보겠습니다.우리는 'Content'필드와 '도구 _calls'필드를 모두 볼 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b6a7e925",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Message content: Hello! I'm here to help you. I have access to a powerful search tool that can help answer questions and find information about various topics. What would you like to know about?\n",
+      "\n",
+      "Feel free to ask any question or request information, and I'll do my best to assist you using the available tools.\n",
+      "\n",
+      "Tool calls: []\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"Hi!\"\n",
+    "response = model_with_tools.invoke([{\"role\": \"user\", \"content\": query}])\n",
+    "\n",
+    "print(f\"Message content: {response.text()}\\n\")\n",
+    "print(f\"Tool calls: {response.tool_calls}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8c81e76",
+   "metadata": {},
+   "source": [
+    "이제 도구를 호출 할 것으로 예상되는 입력으로 호출해 봅시다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "688b465d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Message content: I'll help you search for information about the weather in San Francisco.\n",
+      "\n",
+      "Tool calls: [{'name': 'tavily_search', 'args': {'query': 'current weather San Francisco'}, 'id': 'toolu_015gdPn1jbB2Z21DmN2RAnti', 'type': 'tool_call'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"Search for the weather in SF\"\n",
+    "response = model_with_tools.invoke([{\"role\": \"user\", \"content\": query}])\n",
+    "\n",
+    "print(f\"Message content: {response.text()}\\n\")\n",
+    "print(f\"Tool calls: {response.tool_calls}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83c4bcd3",
+   "metadata": {},
+   "source": [
+    "우리는 이제 텍스트 내용이 없지만 공구 통화가 있음을 알 수 있습니다!그것은 우리가 Tavily 검색 도구를 호출하기를 원합니다.\n",
+    "\n",
+    "이것은 아직 그 도구를 부르는 것이 아닙니다. 단지 우리에게 말하고 있습니다.실제로 그것을 부르려면 에이전트를 만들고 싶습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40ccec80",
+   "metadata": {},
+   "source": [
+    "## 에이전트를 만듭니다\n",
+    "\n",
+    "도구와 LLM을 정의 했으므로 에이전트를 만들 수 있습니다.우리는 [langgraph] (/docs/concepts/architecture/#langgraph)를 사용하여 에이전트를 구성 할 것입니다.\n",
+    "현재, 우리는 에이전트를 구성하기 위해 높은 수준의 인터페이스를 사용하고 있지만, Langgraph의 좋은 점은이 높은 수준의 인터페이스가 에이전트 로직을 수정하려는 경우 저수준의 제어 가능한 API로 뒷받침된다는 것입니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8014c9d",
+   "metadata": {},
+   "source": [
+    "이제 LLM과 도구로 에이전트를 초기화 할 수 있습니다.\n",
+    "\n",
+    "`model_with_tools`가 아닌 'model'을 통과하고 있습니다.`reation_react_agent`는 후드 아래에서 우리를 위해`.bind_tools`를 호출하기 때문입니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "89cf72b4-6046-4b47-8f27-5522d8cb8036",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.prebuilt import create_react_agent\n",
+    "\n",
+    "agent_executor = create_react_agent(model, tools)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4df0e06",
+   "metadata": {},
+   "source": [
+    "## 에이전트를 실행하십시오\n",
+    "\n",
+    "이제 몇 가지 쿼리로 에이전트를 실행할 수 있습니다!현재로서는 모두 ** 무국적 ** 쿼리입니다 (이전 상호 작용을 기억하지 않습니다).에이전트는 상호 작용이 끝날 때 ** Final ** 상태를 반환합니다 (모든 입력을 포함하여 나중에 출력 만 얻는 방법에 대해 볼 수 있습니다).\n",
+    "\n",
+    "먼저, 도구를 호출 할 필요가 없을 때 어떻게 응답하는지 봅시다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "114ba50d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Hi!\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Hello! I'm here to help you with your questions using the available search tools. Please feel free to ask any question, and I'll do my best to find relevant and accurate information for you.\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\"role\": \"user\", \"content\": \"Hi!\"}\n",
+    "response = agent_executor.invoke({\"messages\": [input_message]})\n",
+    "\n",
+    "for message in response[\"messages\"]:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71493a42",
+   "metadata": {},
+   "source": [
+    "후드 아래에서 무슨 일이 일어나고 있는지 (그리고 도구를 부르지 않도록) [Langsmith Trace] (https://smith.langchain.com/public/28311faa-e135-4d6a-ab6b-caecf6482aaa/r)를 살펴볼 수 있습니다.\n",
+    "\n",
+    "이제 도구를 호출 해야하는 예를 들어 보겠습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "77c2f769",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Search for the weather in SF\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "[{'text': \"I'll help you search for weather information in San Francisco. Let me use the search engine to find current weather conditions.\", 'type': 'text'}, {'id': 'toolu_01WWcXGnArosybujpKzdmARZ', 'input': {'query': 'current weather San Francisco SF'}, 'name': 'tavily_search', 'type': 'tool_use'}]\n",
+      "Tool Calls:\n",
+      "  tavily_search (toolu_01WWcXGnArosybujpKzdmARZ)\n",
+      " Call ID: toolu_01WWcXGnArosybujpKzdmARZ\n",
+      "  Args:\n",
+      "    query: current weather San Francisco SF\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: tavily_search\n",
+      "\n",
+      "{\"query\": \"current weather San Francisco SF\", \"follow_up_questions\": null, \"answer\": null, \"images\": [], \"results\": [{\"title\": \"Weather in San Francisco, CA\", \"url\": \"https://www.weatherapi.com/\", \"content\": \"{'location': {'name': 'San Francisco', 'region': 'California', 'country': 'United States of America', 'lat': 37.775, 'lon': -122.4183, 'tz_id': 'America/Los_Angeles', 'localtime_epoch': 1750168606, 'localtime': '2025-06-17 06:56'}, 'current': {'last_updated_epoch': 1750167900, 'last_updated': '2025-06-17 06:45', 'temp_c': 11.7, 'temp_f': 53.1, 'is_day': 1, 'condition': {'text': 'Fog', 'icon': '//cdn.weatherapi.com/weather/64x64/day/248.png', 'code': 1135}, 'wind_mph': 4.0, 'wind_kph': 6.5, 'wind_degree': 215, 'wind_dir': 'SW', 'pressure_mb': 1017.0, 'pressure_in': 30.02, 'precip_mm': 0.0, 'precip_in': 0.0, 'humidity': 86, 'cloud': 0, 'feelslike_c': 11.3, 'feelslike_f': 52.4, 'windchill_c': 8.7, 'windchill_f': 47.7, 'heatindex_c': 9.8, 'heatindex_f': 49.7, 'dewpoint_c': 9.6, 'dewpoint_f': 49.2, 'vis_km': 16.0, 'vis_miles': 9.0, 'uv': 0.0, 'gust_mph': 6.3, 'gust_kph': 10.2}}\", \"score\": 0.885373, \"raw_content\": null}, {\"title\": \"Weather in San Francisco in June 2025\", \"url\": \"https://world-weather.info/forecast/usa/san_francisco/june-2025/\", \"content\": \"Detailed ⚡ San Francisco Weather Forecast for June 2025 - day/night 🌡️ temperatures, precipitations - World-Weather.info. Add the current city. Search. Weather; Archive; Weather Widget °F. World; United States; California; Weather in San Francisco; ... 17 +64° +54° 18 +61° +54° 19\", \"score\": 0.8830044, \"raw_content\": null}], \"response_time\": 2.6}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Based on the search results, here's the current weather in San Francisco:\n",
+      "- Temperature: 53.1°F (11.7°C)\n",
+      "- Conditions: Foggy\n",
+      "- Wind: 4.0 mph from the SW\n",
+      "- Humidity: 86%\n",
+      "- Visibility: 9.0 miles\n",
+      "\n",
+      "The weather appears to be typical for San Francisco, with morning fog and mild temperatures. The \"feels like\" temperature is 52.4°F (11.3°C).\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\"role\": \"user\", \"content\": \"Search for the weather in SF\"}\n",
+    "response = agent_executor.invoke({\"messages\": [input_message]})\n",
+    "\n",
+    "for message in response[\"messages\"]:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c174f838",
+   "metadata": {},
+   "source": [
+    "[Langsmith Trace] (https://smith.langchain.com/public/f520839d-cd4d-4495-8764-e32b548e235d/r)를 검색 도구를 효과적으로 호출 할 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f6ca7e4",
+   "metadata": {},
+   "source": [
+    "## 스트리밍 메시지\n",
+    "\n",
+    "우리는 최종 응답을 얻기 위해`.invoke`를 사용하여 에이전트를 어떻게 호출 할 수 있는지 보았습니다.에이전트가 여러 단계를 수행하면 시간이 걸릴 수 있습니다.중간 진행 상황을 보여주기 위해 메시지가 발생할 때 되돌아 갈 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "bd93812b-2350-4d7f-9643-34c753503754",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Search for the weather in SF\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "[{'text': \"I'll help you search for information about the weather in San Francisco.\", 'type': 'text'}, {'id': 'toolu_01DCPnJES53Fcr7YWnZ47kDG', 'input': {'query': 'current weather San Francisco'}, 'name': 'tavily_search', 'type': 'tool_use'}]\n",
+      "Tool Calls:\n",
+      "  tavily_search (toolu_01DCPnJES53Fcr7YWnZ47kDG)\n",
+      " Call ID: toolu_01DCPnJES53Fcr7YWnZ47kDG\n",
+      "  Args:\n",
+      "    query: current weather San Francisco\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: tavily_search\n",
+      "\n",
+      "{\"query\": \"current weather San Francisco\", \"follow_up_questions\": null, \"answer\": null, \"images\": [], \"results\": [{\"title\": \"Weather in San Francisco\", \"url\": \"https://www.weatherapi.com/\", \"content\": \"{'location': {'name': 'San Francisco', 'region': 'California', 'country': 'United States of America', 'lat': 37.775, 'lon': -122.4183, 'tz_id': 'America/Los_Angeles', 'localtime_epoch': 1750168506, 'localtime': '2025-06-17 06:55'}, 'current': {'last_updated_epoch': 1750167900, 'last_updated': '2025-06-17 06:45', 'temp_c': 11.7, 'temp_f': 53.1, 'is_day': 1, 'condition': {'text': 'Fog', 'icon': '//cdn.weatherapi.com/weather/64x64/day/248.png', 'code': 1135}, 'wind_mph': 4.0, 'wind_kph': 6.5, 'wind_degree': 215, 'wind_dir': 'SW', 'pressure_mb': 1017.0, 'pressure_in': 30.02, 'precip_mm': 0.0, 'precip_in': 0.0, 'humidity': 86, 'cloud': 0, 'feelslike_c': 11.3, 'feelslike_f': 52.4, 'windchill_c': 8.7, 'windchill_f': 47.7, 'heatindex_c': 9.8, 'heatindex_f': 49.7, 'dewpoint_c': 9.6, 'dewpoint_f': 49.2, 'vis_km': 16.0, 'vis_miles': 9.0, 'uv': 0.0, 'gust_mph': 6.3, 'gust_kph': 10.2}}\", \"score\": 0.9542825, \"raw_content\": null}, {\"title\": \"Weather in San Francisco in June 2025\", \"url\": \"https://world-weather.info/forecast/usa/san_francisco/june-2025/\", \"content\": \"Detailed ⚡ San Francisco Weather Forecast for June 2025 - day/night 🌡️ temperatures, precipitations - World-Weather.info. Add the current city. Search. Weather; Archive; Weather Widget °F. World; United States; California; Weather in San Francisco; ... 17 +64° +54° 18 +61° +54° 19\", \"score\": 0.8638634, \"raw_content\": null}], \"response_time\": 2.57}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Based on the search results, here's the current weather in San Francisco:\n",
+      "- Temperature: 53.1°F (11.7°C)\n",
+      "- Condition: Foggy\n",
+      "- Wind: 4.0 mph from the Southwest\n",
+      "- Humidity: 86%\n",
+      "- Visibility: 9.0 miles\n",
+      "- Feels like: 52.4°F (11.3°C)\n",
+      "\n",
+      "This is quite typical weather for San Francisco, which is known for its fog, especially during the morning hours. The city's proximity to the ocean and unique geographical features often result in mild temperatures and foggy conditions.\n"
+     ]
+    }
+   ],
+   "source": [
+    "for step in agent_executor.stream({\"messages\": [input_message]}, stream_mode=\"values\"):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c72b3043",
+   "metadata": {},
+   "source": [
+    "## 스트리밍 토큰\n",
+    "\n",
+    "후면 메시지를 스트리밍하는 것 외에도 다시 토큰을 스트리밍하는 것이 유용합니다.\n",
+    "`stream_mode = \"message\"`을 지정하여이를 수행 할 수 있습니다.\n",
+    "\n",
+    "\n",
+    "::: 메모\n",
+    "\n",
+    "아래에서는`message.text ()`을 사용하며`langchain-core> = 0.3.37`가 필요합니다.\n",
+    "\n",
+    ":::\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "63198158-380e-43a3-a2ad-d4288949c1d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I|'ll help you search for information| about the weather in San Francisco.|Base|d on the search results, here|'s the current weather in| San Francisco:\n",
+      "-| Temperature: 53.1°F (|11.7°C)\n",
+      "-| Condition: Foggy\n",
+      "- Wind:| 4.0 mph from| the Southwest\n",
+      "- Humidity|: 86%|\n",
+      "- Visibility: 9|.0 miles\n",
+      "- Pressure: |30.02 in|Hg\n",
+      "\n",
+      "The weather| is characteristic of San Francisco, with| foggy conditions and mild temperatures|. The \"feels like\" temperature is slightly| lower at 52.4|°F (11.|3°C)| due to the wind chill effect|.|"
+     ]
+    }
+   ],
+   "source": [
+    "for step, metadata in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, stream_mode=\"messages\"\n",
+    "):\n",
+    "    if metadata[\"langgraph_node\"] == \"agent\" and (text := step.text()):\n",
+    "        print(text, end=\"|\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "022cbc8a",
+   "metadata": {},
+   "source": [
+    "## 메모리 추가\n",
+    "\n",
+    "앞에서 언급 했듯이이 에이전트는 상태가 없습니다.이것은 이전 상호 작용을 기억하지 못한다는 것을 의미합니다.메모리를 제공하려면 체크 포인터를 통과해야합니다.체크 포인터를 통과 할 때 에이전트를 호출 할 때`thread_id`도 전달해야합니다 (따라서 재개 할 스레드/대화를 알고 있습니다).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "c4073e35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.checkpoint.memory import MemorySaver\n",
+    "\n",
+    "memory = MemorySaver()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "e64a944e-f9ac-43cf-903c-d3d28d765377",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent_executor = create_react_agent(model, tools, checkpointer=memory)\n",
+    "\n",
+    "config = {\"configurable\": {\"thread_id\": \"abc123\"}}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "a13462d0-2d02-4474-921e-15a1ba1fa274",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Hi, I'm Bob!\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Hello Bob! I'm an AI assistant who can help you search for information using specialized search tools. Is there anything specific you'd like to know about or search for? I'm happy to help you find accurate and up-to-date information on various topics.\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\"role\": \"user\", \"content\": \"Hi, I'm Bob!\"}\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "56d8028b-5dbc-40b2-86f5-ed60631d86a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What's my name?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Your name is Bob, as you introduced yourself earlier. I can remember information shared within our conversation without needing to search for it.\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\"role\": \"user\", \"content\": \"What's my name?\"}\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bda99754-0a11-4447-b408-e8db8f2e3517",
+   "metadata": {},
+   "source": [
+    "예 [Langsmith Trace] (https://smith.langchain.com/public/fa73960b-0f7d-4910-b73d-757a12f33b2b/r)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae908088",
+   "metadata": {},
+   "source": [
+    "새로운 대화를 시작하려면`thrable_id`를 변경하기 만하면됩니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "24460239",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What's my name?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "I apologize, but I don't have access to any tools that would tell me your name. I can only assist you with searching for publicly available information using the tavily_search function. I don't have access to personal information about users. If you'd like to tell me your name, I'll be happy to address you by it.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# highlight-next-line\n",
+    "config = {\"configurable\": {\"thread_id\": \"xyz123\"}}\n",
+    "\n",
+    "input_message = {\"role\": \"user\", \"content\": \"What's my name?\"}\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c029798f",
+   "metadata": {},
+   "source": [
+    "## 결론\n",
+    "\n",
+    "그것은 랩입니다!이 빠른 시작에서 우리는 간단한 에이전트를 만드는 방법을 다루었습니다.\n",
+    "그런 다음 중간 단계뿐만 아니라 토큰으로 응답을 되 찾는 방법을 보여주었습니다!\n",
+    "우리는 또한 메모리에 추가하여 대화를 나눌 수 있습니다.\n",
+    "에이전트는 배울 것이 많은 복잡한 주제입니다!\n",
+    "\n",
+    "에이전트에 대한 자세한 내용은 [langgraph] (/docs/concepts/architecture/#langgraph) 문서를 확인하십시오.여기에는 자체 개념, 튜토리얼 및 방법 안내서 세트가 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3ec3244",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add Korean-translated version of the agents tutorial notebook for Korean-speaking users.

## Testing
- `pre-commit run --files docs/docs/tutorials/agents_ko.ipynb`

------
https://chatgpt.com/codex/tasks/task_e_68a16b07bd648332ac27dd49a54e4ee9