### PR TITLE
Add Korean translations of agents and summarization tutorial notebooks

### DIFF
--- a/docs/docs/tutorials/agents_ko.ipynb
+++ b/docs/docs/tutorials/agents_ko.ipynb
@@ -1,0 +1,837 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "17546ebb",
+   "metadata": {
+    "vscode": {
+     "languageId": "raw"
+    }
+   },
+   "source": [
+    "---\n",
+    "keywords: [agent, agents]\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1df78a71",
+   "metadata": {},
+   "source": [
+    "# 에이전트를 구축하십시오\n",
+    "\n",
+    "Langchain은 [에이전트] (/docs/concepts/agents) 또는 [LLMS] (/docs/concepts/chat_models)를 사용하는 시스템의 생성을 지원하여 엔진을 추론하여 동작을 수행하는 데 필요한 작업 및 입력을 결정합니다.\n",
+    "작업을 실행 한 후 결과를 LLM으로 Fed Back으로 공급하여 더 많은 작업이 필요한지 또는 완료하는 것이 괜찮은지 여부를 결정할 수 있습니다.이것은 종종 [Tool-Calling] (/docs/concepts/tool_calling)를 통해 달성됩니다.\n",
+    "\n",
+    "이 튜토리얼에서는 검색 엔진과 상호 작용할 수있는 에이전트를 구축합니다.이 에이전트 질문을하고 검색 도구에 전화를 걸고 대화를 할 수 있습니다.\n",
+    "\n",
+    "## 엔드 투 엔드 에이전트\n",
+    "\n",
+    "아래 코드 스 니펫은 LLM을 사용하여 사용할 도구를 결정하는 완벽한 기능 에이전트를 나타냅니다.일반 검색 도구가 장착되어 있습니다.대화 메모리가 있습니다. 즉, 다중 전환 챗봇으로 사용할 수 있음을 의미합니다.\n",
+    "\n",
+    "가이드의 나머지 부분에서는 개별 구성 요소와 각 부분이하는 일을 안내하지만 코드를 잡고 시작하려면 자유롭게 사용하십시오!\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "86d9386b-442f-4cd6-a78f-57c88249d3f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import relevant functionality\n",
+    "from langchain.chat_models import init_chat_model\n",
+    "from langchain_tavily import TavilySearch\n",
+    "from langgraph.checkpoint.memory import MemorySaver\n",
+    "from langgraph.prebuilt import create_react_agent\n",
+    "\n",
+    "# Create the agent\n",
+    "memory = MemorySaver()\n",
+    "model = init_chat_model(\"anthropic:claude-3-5-sonnet-latest\")\n",
+    "search = TavilySearch(max_results=2)\n",
+    "tools = [search]\n",
+    "agent_executor = create_react_agent(model, tools, checkpointer=memory)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7ab50503-d09f-4ff4-9080-5afe297ccc38",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Hi, I'm Bob and I live in SF.\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Hello Bob! I notice you've introduced yourself and mentioned you live in SF (San Francisco), but you haven't asked a specific question or made a request that requires the use of any tools. Is there something specific you'd like to know about San Francisco or any other topic? I'd be happy to help you find information using the available search tools.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Use the agent\n",
+    "config = {\"configurable\": {\"thread_id\": \"abc123\"}}\n",
+    "\n",
+    "input_message = {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": \"Hi, I'm Bob and I live in SF.\",\n",
+    "}\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "fcadb699-3787-4028-a5f6-e5605c8118d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What's the weather where I live?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "[{'text': 'Let me search for current weather information in San Francisco.', 'type': 'text'}, {'id': 'toolu_011kSdheoJp8THURoLmeLtZo', 'input': {'query': 'current weather San Francisco CA'}, 'name': 'tavily_search', 'type': 'tool_use'}]\n",
+      "Tool Calls:\n",
+      "  tavily_search (toolu_011kSdheoJp8THURoLmeLtZo)\n",
+      " Call ID: toolu_011kSdheoJp8THURoLmeLtZo\n",
+      "  Args:\n",
+      "    query: current weather San Francisco CA\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: tavily_search\n",
+      "\n",
+      "{\"query\": \"current weather San Francisco CA\", \"follow_up_questions\": null, \"answer\": null, \"images\": [], \"results\": [{\"title\": \"Weather in San Francisco, CA\", \"url\": \"https://www.weatherapi.com/\", \"content\": \"{'location': {'name': 'San Francisco', 'region': 'California', 'country': 'United States of America', 'lat': 37.775, 'lon': -122.4183, 'tz_id': 'America/Los_Angeles', 'localtime_epoch': 1750168606, 'localtime': '2025-06-17 06:56'}, 'current': {'last_updated_epoch': 1750167900, 'last_updated': '2025-06-17 06:45', 'temp_c': 11.7, 'temp_f': 53.1, 'is_day': 1, 'condition': {'text': 'Fog', 'icon': '//cdn.weatherapi.com/weather/64x64/day/248.png', 'code': 1135}, 'wind_mph': 4.0, 'wind_kph': 6.5, 'wind_degree': 215, 'wind_dir': 'SW', 'pressure_mb': 1017.0, 'pressure_in': 30.02, 'precip_mm': 0.0, 'precip_in': 0.0, 'humidity': 86, 'cloud': 0, 'feelslike_c': 11.3, 'feelslike_f': 52.4, 'windchill_c': 8.7, 'windchill_f': 47.7, 'heatindex_c': 9.8, 'heatindex_f': 49.7, 'dewpoint_c': 9.6, 'dewpoint_f': 49.2, 'vis_km': 16.0, 'vis_miles': 9.0, 'uv': 0.0, 'gust_mph': 6.3, 'gust_kph': 10.2}}\", \"score\": 0.944705, \"raw_content\": null}, {\"title\": \"Weather in San Francisco in June 2025\", \"url\": \"https://world-weather.info/forecast/usa/san_francisco/june-2025/\", \"content\": \"Detailed ⚡ San Francisco Weather Forecast for June 2025 - day/night 🌡️ temperatures, precipitations - World-Weather.info. Add the current city. Search. Weather; Archive; Weather Widget °F. World; United States; California; Weather in San Francisco; ... 17 +64° +54° 18 +61° +54° 19\", \"score\": 0.86441374, \"raw_content\": null}], \"response_time\": 2.34}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Based on the search results, here's the current weather in San Francisco:\n",
+      "- Temperature: 53.1°F (11.7°C)\n",
+      "- Condition: Foggy\n",
+      "- Wind: 4.0 mph from the Southwest\n",
+      "- Humidity: 86%\n",
+      "- Visibility: 9 miles\n",
+      "\n",
+      "This is quite typical weather for San Francisco, with the characteristic fog that the city is known for. Would you like to know anything else about the weather or San Francisco in general?\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\n",
+    "    \"role\": \"user\",\n",
+    "    \"content\": \"What's the weather where I live?\",\n",
+    "}\n",
+    "\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4c03f40-1328-412d-8a48-1db0cd481b77",
+   "metadata": {},
+   "source": [
+    "## 설정\n",
+    "\n",
+    "### Jupyter 노트\n",
+    "\n",
+    "이 안내서 (및 문서의 다른 가이드 대부분)는 [Jupyter Notebooks] (https://jupyter.org/)를 사용하고 독자도 마찬가지라고 가정합니다.Jupyter 노트북은 LLM 시스템을 사용하는 방법을 배우기위한 완벽한 대화식 환경입니다. 왜냐하면 종종 일이 잘못 될 수 있기 때문에 (예기치 않은 출력, API 다운 등), 이러한 사례를 관찰하는 것은 LLM으로 건축을 더 잘 이해하는 좋은 방법입니다.\n",
+    "\n",
+    "이 튜토리얼과 다른 튜토리얼은 아마도 Jupyter 노트북에서 가장 편리하게 실행됩니다.설치 방법에 대한 지침은 [여기] (https://jupyter.org/install)을 참조하십시오.\n",
+    "\n",
+    "### 설치\n",
+    "\n",
+    "Langchain Run을 설치하려면 :\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60bb3eb1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -U langgraph langchain-tavily langgraph-checkpoint-sqlite"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ee337ae",
+   "metadata": {},
+   "source": [
+    "자세한 내용은 [설치 안내서] (/docs/how_to/installation)를 참조하십시오.\n",
+    "\n",
+    "### Langsmith\n",
+    "\n",
+    "Langchain으로 구축 한 많은 응용 프로그램에는 LLM 통화가 여러 번 발생하여 여러 단계가 포함됩니다.\n",
+    "이러한 응용 프로그램이 점점 더 복잡해지면 체인이나 에이전트 내에서 정확히 무슨 일이 일어나고 있는지 검사하는 것이 중요합니다.\n",
+    "이를 수행하는 가장 좋은 방법은 [langsmith] (https://smith.langchain.com)입니다.\n",
+    "\n",
+    "위의 링크에 가입 한 후에는 환경 변수를 로깅 추적을 시작하도록 설정하십시오.\n",
+    "\n",
+    "```쉘\n",
+    "내보내기 langsmith_tracing = \"true\"\n",
+    "내보내기 langsmith_api_key = \"...\"\n",
+    "```\n",
+    "\n",
+    "또는 노트북에 있으면 다음과 같이 설정할 수 있습니다.\n",
+    "\n",
+    "```Python\n",
+    "getpass 가져 오기\n",
+    "OS 가져 오기\n",
+    "\n",
+    "os.environ [ \"langsmith_tracing\"] = \"true\"\n",
+    "os.environ [ \"langsmith_api_key\"] = getpass.getpass ()\n",
+    "```\n",
+    "\n",
+    "### tavily\n",
+    "\n",
+    "우리는 [tavily] (/docs/integrations/tools/tavily_search) (검색 엔진)을 도구로 사용할 것입니다.\n",
+    "이를 사용하려면 API 키를 가져 와서 설정해야합니다.\n",
+    "\n",
+    "```Bash\n",
+    "tavily_api_key = \"...\"내보내기\n",
+    "```\n",
+    "\n",
+    "또는 노트북에 있으면 다음과 같이 설정할 수 있습니다.\n",
+    "\n",
+    "```Python\n",
+    "getpass 가져 오기\n",
+    "OS 가져 오기\n",
+    "\n",
+    "os.environ [ \"tavily_api_key\"] = getpass.getpass ()\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c335d1bf",
+   "metadata": {},
+   "source": [
+    "## 도구 정의\n",
+    "\n",
+    "먼저 사용하려는 도구를 만들어야합니다.우리의 주요 선택 도구는 검색 엔진 인 [tavily] (/docs/integrations/tools/tavily_search)입니다.우리는 전용 [langchain-tavily] (https://pypi.org/project/langchain-tavily/) [통합 패키지] (/docs/concepts/architecture/#통합-패키지)을 Langchain과 함께 도구로 쉽게 사용할 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "76a02d36-6ea2-4e62-88b4-6c480dd9c04f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'query': 'What is the weather in SF', 'follow_up_questions': None, 'answer': None, 'images': [], 'results': [{'title': 'Weather in San Francisco, CA', 'url': 'https://www.weatherapi.com/', 'content': \"{'location': {'name': 'San Francisco', 'region': 'California', 'country': 'United States of America', 'lat': 37.775, 'lon': -122.4183, 'tz_id': 'America/Los_Angeles', 'localtime_epoch': 1750168606, 'localtime': '2025-06-17 06:56'}, 'current': {'last_updated_epoch': 1750167900, 'last_updated': '2025-06-17 06:45', 'temp_c': 11.7, 'temp_f': 53.1, 'is_day': 1, 'condition': {'text': 'Fog', 'icon': '//cdn.weatherapi.com/weather/64x64/day/248.png', 'code': 1135}, 'wind_mph': 4.0, 'wind_kph': 6.5, 'wind_degree': 215, 'wind_dir': 'SW', 'pressure_mb': 1017.0, 'pressure_in': 30.02, 'precip_mm': 0.0, 'precip_in': 0.0, 'humidity': 86, 'cloud': 0, 'feelslike_c': 11.3, 'feelslike_f': 52.4, 'windchill_c': 8.7, 'windchill_f': 47.7, 'heatindex_c': 9.8, 'heatindex_f': 49.7, 'dewpoint_c': 9.6, 'dewpoint_f': 49.2, 'vis_km': 16.0, 'vis_miles': 9.0, 'uv': 0.0, 'gust_mph': 6.3, 'gust_kph': 10.2}}\", 'score': 0.9185379, 'raw_content': None}, {'title': 'Weather in San Francisco in June 2025', 'url': 'https://world-weather.info/forecast/usa/san_francisco/june-2025/', 'content': \"Weather in San Francisco in June 2025 (California) - Detailed Weather Forecast for a Month *   Weather in San Francisco Weather in San Francisco in June 2025 *   1 +63° +55° *   2 +66° +54° *   3 +66° +55° *   4 +66° +54° *   5 +66° +55° *   6 +66° +57° *   7 +64° +55° *   8 +63° +55° *   9 +63° +54° *   10 +59° +54° *   11 +59° +54° *   12 +61° +54° Weather in Washington, D.C.**+68°** Sacramento**+81°** Pleasanton**+72°** Redwood City**+68°** San Leandro**+61°** San Mateo**+64°** San Rafael**+70°** San Ramon**+64°** South San Francisco**+61°** Daly City**+59°** Wilder**+66°** Woodacre**+70°** world's temperature today Colchani day+50°F night+16°F Az Zubayr day+124°F night+93°F Weather forecast on your site Install _San Francisco_ +61° Temperature units\", 'score': 0.7978881, 'raw_content': None}], 'response_time': 2.62}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_tavily import TavilySearch\n",
+    "\n",
+    "search = TavilySearch(max_results=2)\n",
+    "search_results = search.invoke(\"What is the weather in SF\")\n",
+    "print(search_results)\n",
+    "# If we want, we can create other tools.\n",
+    "# Once we have all the tools we want, we can put them in a list that we will reference later.\n",
+    "tools = [search]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ecbc86d8",
+   "metadata": {},
+   "source": [
+    ":::팁\n",
+    "\n",
+    "많은 응용 분야에서 사용자 정의 도구를 정의 할 수 있습니다.Langchain은 관습을 지원합니다\n",
+    "파이썬 기능 및 기타 수단을 통한 도구 생성.참조\n",
+    "[도구를 만드는 방법] (/docs/how_to/custom_tools/) 자세한 내용은 안내서.\n",
+    "\n",
+    ":::\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e00068b0",
+   "metadata": {},
+   "source": [
+    "## 언어 모델 사용\n",
+    "\n",
+    "다음으로 언어 모델을 사용하여 도구를 호출하는 방법을 배우겠습니다.Langchain은 상호 교환 할 수있는 다양한 언어 모델을 지원합니다. 아래에서 사용할 것을 선택하십시오!\n",
+    "\n",
+    "\"@테마/chatmodeltabs\"에서 chatmodeltabs 가져 오기;\n",
+    "\n",
+    "<chatmodeltabs atedrideparams = {{openai : {model : \"gpt-4.1\"}} />\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "69185491",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# | output: false\n",
+    "# | echo: false\n",
+    "\n",
+    "from langchain_anthropic import ChatAnthropic\n",
+    "\n",
+    "model = ChatAnthropic(model=\"claude-3-5-sonnet-latest\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "642ed8bf",
+   "metadata": {},
+   "source": [
+    "메시지 목록을 전달하여 언어 모델을 호출 할 수 있습니다.기본적으로 응답은 'content'문자열입니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c96c960b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Hello! How can I help you today?'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = \"Hi!\"\n",
+    "response = model.invoke([{\"role\": \"user\", \"content\": query}])\n",
+    "response.text()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47bf8210",
+   "metadata": {},
+   "source": [
+    "이제이 모델이 도구 호출을 수행 할 수 있도록하는 것이 어떤지 확인할 수 있습니다.우리가`.bind_tools`를 사용하여 이러한 도구에 대한 언어 모델 지식을 제공 할 수 있도록\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ba692a74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_with_tools = model.bind_tools(tools)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd920b69",
+   "metadata": {},
+   "source": [
+    "이제 모델을 호출 할 수 있습니다.먼저 일반 메시지로 전화하여 어떻게 응답하는지 살펴 보겠습니다.우리는 'Content'필드와 '도구 _calls'필드를 모두 볼 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b6a7e925",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Message content: Hello! I'm here to help you. I have access to a powerful search tool that can help answer questions and find information about various topics. What would you like to know about?\n",
+      "\n",
+      "Feel free to ask any question or request information, and I'll do my best to assist you using the available tools.\n",
+      "\n",
+      "Tool calls: []\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"Hi!\"\n",
+    "response = model_with_tools.invoke([{\"role\": \"user\", \"content\": query}])\n",
+    "\n",
+    "print(f\"Message content: {response.text()}\\n\")\n",
+    "print(f\"Tool calls: {response.tool_calls}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8c81e76",
+   "metadata": {},
+   "source": [
+    "이제 도구를 호출 할 것으로 예상되는 입력으로 호출해 봅시다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "688b465d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Message content: I'll help you search for information about the weather in San Francisco.\n",
+      "\n",
+      "Tool calls: [{'name': 'tavily_search', 'args': {'query': 'current weather San Francisco'}, 'id': 'toolu_015gdPn1jbB2Z21DmN2RAnti', 'type': 'tool_call'}]\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"Search for the weather in SF\"\n",
+    "response = model_with_tools.invoke([{\"role\": \"user\", \"content\": query}])\n",
+    "\n",
+    "print(f\"Message content: {response.text()}\\n\")\n",
+    "print(f\"Tool calls: {response.tool_calls}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83c4bcd3",
+   "metadata": {},
+   "source": [
+    "우리는 이제 텍스트 내용이 없지만 공구 통화가 있음을 알 수 있습니다!그것은 우리가 Tavily 검색 도구를 호출하기를 원합니다.\n",
+    "\n",
+    "이것은 아직 그 도구를 부르는 것이 아닙니다. 단지 우리에게 말하고 있습니다.실제로 그것을 부르려면 에이전트를 만들고 싶습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40ccec80",
+   "metadata": {},
+   "source": [
+    "## 에이전트를 만듭니다\n",
+    "\n",
+    "도구와 LLM을 정의 했으므로 에이전트를 만들 수 있습니다.우리는 [langgraph] (/docs/concepts/architecture/#langgraph)를 사용하여 에이전트를 구성 할 것입니다.\n",
+    "현재, 우리는 에이전트를 구성하기 위해 높은 수준의 인터페이스를 사용하고 있지만, Langgraph의 좋은 점은이 높은 수준의 인터페이스가 에이전트 로직을 수정하려는 경우 저수준의 제어 가능한 API로 뒷받침된다는 것입니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8014c9d",
+   "metadata": {},
+   "source": [
+    "이제 LLM과 도구로 에이전트를 초기화 할 수 있습니다.\n",
+    "\n",
+    "`model_with_tools`가 아닌 'model'을 통과하고 있습니다.`reation_react_agent`는 후드 아래에서 우리를 위해`.bind_tools`를 호출하기 때문입니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "89cf72b4-6046-4b47-8f27-5522d8cb8036",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.prebuilt import create_react_agent\n",
+    "\n",
+    "agent_executor = create_react_agent(model, tools)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4df0e06",
+   "metadata": {},
+   "source": [
+    "## 에이전트를 실행하십시오\n",
+    "\n",
+    "이제 몇 가지 쿼리로 에이전트를 실행할 수 있습니다!현재로서는 모두 ** 무국적 ** 쿼리입니다 (이전 상호 작용을 기억하지 않습니다).에이전트는 상호 작용이 끝날 때 ** Final ** 상태를 반환합니다 (모든 입력을 포함하여 나중에 출력 만 얻는 방법에 대해 볼 수 있습니다).\n",
+    "\n",
+    "먼저, 도구를 호출 할 필요가 없을 때 어떻게 응답하는지 봅시다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "114ba50d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Hi!\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Hello! I'm here to help you with your questions using the available search tools. Please feel free to ask any question, and I'll do my best to find relevant and accurate information for you.\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\"role\": \"user\", \"content\": \"Hi!\"}\n",
+    "response = agent_executor.invoke({\"messages\": [input_message]})\n",
+    "\n",
+    "for message in response[\"messages\"]:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71493a42",
+   "metadata": {},
+   "source": [
+    "후드 아래에서 무슨 일이 일어나고 있는지 (그리고 도구를 부르지 않도록) [Langsmith Trace] (https://smith.langchain.com/public/28311faa-e135-4d6a-ab6b-caecf6482aaa/r)를 살펴볼 수 있습니다.\n",
+    "\n",
+    "이제 도구를 호출 해야하는 예를 들어 보겠습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "77c2f769",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Search for the weather in SF\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "[{'text': \"I'll help you search for weather information in San Francisco. Let me use the search engine to find current weather conditions.\", 'type': 'text'}, {'id': 'toolu_01WWcXGnArosybujpKzdmARZ', 'input': {'query': 'current weather San Francisco SF'}, 'name': 'tavily_search', 'type': 'tool_use'}]\n",
+      "Tool Calls:\n",
+      "  tavily_search (toolu_01WWcXGnArosybujpKzdmARZ)\n",
+      " Call ID: toolu_01WWcXGnArosybujpKzdmARZ\n",
+      "  Args:\n",
+      "    query: current weather San Francisco SF\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: tavily_search\n",
+      "\n",
+      "{\"query\": \"current weather San Francisco SF\", \"follow_up_questions\": null, \"answer\": null, \"images\": [], \"results\": [{\"title\": \"Weather in San Francisco, CA\", \"url\": \"https://www.weatherapi.com/\", \"content\": \"{'location': {'name': 'San Francisco', 'region': 'California', 'country': 'United States of America', 'lat': 37.775, 'lon': -122.4183, 'tz_id': 'America/Los_Angeles', 'localtime_epoch': 1750168606, 'localtime': '2025-06-17 06:56'}, 'current': {'last_updated_epoch': 1750167900, 'last_updated': '2025-06-17 06:45', 'temp_c': 11.7, 'temp_f': 53.1, 'is_day': 1, 'condition': {'text': 'Fog', 'icon': '//cdn.weatherapi.com/weather/64x64/day/248.png', 'code': 1135}, 'wind_mph': 4.0, 'wind_kph': 6.5, 'wind_degree': 215, 'wind_dir': 'SW', 'pressure_mb': 1017.0, 'pressure_in': 30.02, 'precip_mm': 0.0, 'precip_in': 0.0, 'humidity': 86, 'cloud': 0, 'feelslike_c': 11.3, 'feelslike_f': 52.4, 'windchill_c': 8.7, 'windchill_f': 47.7, 'heatindex_c': 9.8, 'heatindex_f': 49.7, 'dewpoint_c': 9.6, 'dewpoint_f': 49.2, 'vis_km': 16.0, 'vis_miles': 9.0, 'uv': 0.0, 'gust_mph': 6.3, 'gust_kph': 10.2}}\", \"score\": 0.885373, \"raw_content\": null}, {\"title\": \"Weather in San Francisco in June 2025\", \"url\": \"https://world-weather.info/forecast/usa/san_francisco/june-2025/\", \"content\": \"Detailed ⚡ San Francisco Weather Forecast for June 2025 - day/night 🌡️ temperatures, precipitations - World-Weather.info. Add the current city. Search. Weather; Archive; Weather Widget °F. World; United States; California; Weather in San Francisco; ... 17 +64° +54° 18 +61° +54° 19\", \"score\": 0.8830044, \"raw_content\": null}], \"response_time\": 2.6}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Based on the search results, here's the current weather in San Francisco:\n",
+      "- Temperature: 53.1°F (11.7°C)\n",
+      "- Conditions: Foggy\n",
+      "- Wind: 4.0 mph from the SW\n",
+      "- Humidity: 86%\n",
+      "- Visibility: 9.0 miles\n",
+      "\n",
+      "The weather appears to be typical for San Francisco, with morning fog and mild temperatures. The \"feels like\" temperature is 52.4°F (11.3°C).\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\"role\": \"user\", \"content\": \"Search for the weather in SF\"}\n",
+    "response = agent_executor.invoke({\"messages\": [input_message]})\n",
+    "\n",
+    "for message in response[\"messages\"]:\n",
+    "    message.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c174f838",
+   "metadata": {},
+   "source": [
+    "[Langsmith Trace] (https://smith.langchain.com/public/f520839d-cd4d-4495-8764-e32b548e235d/r)를 검색 도구를 효과적으로 호출 할 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f6ca7e4",
+   "metadata": {},
+   "source": [
+    "## 스트리밍 메시지\n",
+    "\n",
+    "우리는 최종 응답을 얻기 위해`.invoke`를 사용하여 에이전트를 어떻게 호출 할 수 있는지 보았습니다.에이전트가 여러 단계를 수행하면 시간이 걸릴 수 있습니다.중간 진행 상황을 보여주기 위해 메시지가 발생할 때 되돌아 갈 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "bd93812b-2350-4d7f-9643-34c753503754",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Search for the weather in SF\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "[{'text': \"I'll help you search for information about the weather in San Francisco.\", 'type': 'text'}, {'id': 'toolu_01DCPnJES53Fcr7YWnZ47kDG', 'input': {'query': 'current weather San Francisco'}, 'name': 'tavily_search', 'type': 'tool_use'}]\n",
+      "Tool Calls:\n",
+      "  tavily_search (toolu_01DCPnJES53Fcr7YWnZ47kDG)\n",
+      " Call ID: toolu_01DCPnJES53Fcr7YWnZ47kDG\n",
+      "  Args:\n",
+      "    query: current weather San Francisco\n",
+      "=================================\u001b[1m Tool Message \u001b[0m=================================\n",
+      "Name: tavily_search\n",
+      "\n",
+      "{\"query\": \"current weather San Francisco\", \"follow_up_questions\": null, \"answer\": null, \"images\": [], \"results\": [{\"title\": \"Weather in San Francisco\", \"url\": \"https://www.weatherapi.com/\", \"content\": \"{'location': {'name': 'San Francisco', 'region': 'California', 'country': 'United States of America', 'lat': 37.775, 'lon': -122.4183, 'tz_id': 'America/Los_Angeles', 'localtime_epoch': 1750168506, 'localtime': '2025-06-17 06:55'}, 'current': {'last_updated_epoch': 1750167900, 'last_updated': '2025-06-17 06:45', 'temp_c': 11.7, 'temp_f': 53.1, 'is_day': 1, 'condition': {'text': 'Fog', 'icon': '//cdn.weatherapi.com/weather/64x64/day/248.png', 'code': 1135}, 'wind_mph': 4.0, 'wind_kph': 6.5, 'wind_degree': 215, 'wind_dir': 'SW', 'pressure_mb': 1017.0, 'pressure_in': 30.02, 'precip_mm': 0.0, 'precip_in': 0.0, 'humidity': 86, 'cloud': 0, 'feelslike_c': 11.3, 'feelslike_f': 52.4, 'windchill_c': 8.7, 'windchill_f': 47.7, 'heatindex_c': 9.8, 'heatindex_f': 49.7, 'dewpoint_c': 9.6, 'dewpoint_f': 49.2, 'vis_km': 16.0, 'vis_miles': 9.0, 'uv': 0.0, 'gust_mph': 6.3, 'gust_kph': 10.2}}\", \"score\": 0.9542825, \"raw_content\": null}, {\"title\": \"Weather in San Francisco in June 2025\", \"url\": \"https://world-weather.info/forecast/usa/san_francisco/june-2025/\", \"content\": \"Detailed ⚡ San Francisco Weather Forecast for June 2025 - day/night 🌡️ temperatures, precipitations - World-Weather.info. Add the current city. Search. Weather; Archive; Weather Widget °F. World; United States; California; Weather in San Francisco; ... 17 +64° +54° 18 +61° +54° 19\", \"score\": 0.8638634, \"raw_content\": null}], \"response_time\": 2.57}\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Based on the search results, here's the current weather in San Francisco:\n",
+      "- Temperature: 53.1°F (11.7°C)\n",
+      "- Condition: Foggy\n",
+      "- Wind: 4.0 mph from the Southwest\n",
+      "- Humidity: 86%\n",
+      "- Visibility: 9.0 miles\n",
+      "- Feels like: 52.4°F (11.3°C)\n",
+      "\n",
+      "This is quite typical weather for San Francisco, which is known for its fog, especially during the morning hours. The city's proximity to the ocean and unique geographical features often result in mild temperatures and foggy conditions.\n"
+     ]
+    }
+   ],
+   "source": [
+    "for step in agent_executor.stream({\"messages\": [input_message]}, stream_mode=\"values\"):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c72b3043",
+   "metadata": {},
+   "source": [
+    "## 스트리밍 토큰\n",
+    "\n",
+    "후면 메시지를 스트리밍하는 것 외에도 다시 토큰을 스트리밍하는 것이 유용합니다.\n",
+    "`stream_mode = \"message\"`을 지정하여이를 수행 할 수 있습니다.\n",
+    "\n",
+    "\n",
+    "::: 메모\n",
+    "\n",
+    "아래에서는`message.text ()`을 사용하며`langchain-core> = 0.3.37`가 필요합니다.\n",
+    "\n",
+    ":::\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "63198158-380e-43a3-a2ad-d4288949c1d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "I|'ll help you search for information| about the weather in San Francisco.|Base|d on the search results, here|'s the current weather in| San Francisco:\n",
+      "-| Temperature: 53.1°F (|11.7°C)\n",
+      "-| Condition: Foggy\n",
+      "- Wind:| 4.0 mph from| the Southwest\n",
+      "- Humidity|: 86%|\n",
+      "- Visibility: 9|.0 miles\n",
+      "- Pressure: |30.02 in|Hg\n",
+      "\n",
+      "The weather| is characteristic of San Francisco, with| foggy conditions and mild temperatures|. The \"feels like\" temperature is slightly| lower at 52.4|°F (11.|3°C)| due to the wind chill effect|.|"
+     ]
+    }
+   ],
+   "source": [
+    "for step, metadata in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, stream_mode=\"messages\"\n",
+    "):\n",
+    "    if metadata[\"langgraph_node\"] == \"agent\" and (text := step.text()):\n",
+    "        print(text, end=\"|\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "022cbc8a",
+   "metadata": {},
+   "source": [
+    "## 메모리 추가\n",
+    "\n",
+    "앞에서 언급 했듯이이 에이전트는 상태가 없습니다.이것은 이전 상호 작용을 기억하지 못한다는 것을 의미합니다.메모리를 제공하려면 체크 포인터를 통과해야합니다.체크 포인터를 통과 할 때 에이전트를 호출 할 때`thread_id`도 전달해야합니다 (따라서 재개 할 스레드/대화를 알고 있습니다).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "c4073e35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langgraph.checkpoint.memory import MemorySaver\n",
+    "\n",
+    "memory = MemorySaver()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "e64a944e-f9ac-43cf-903c-d3d28d765377",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent_executor = create_react_agent(model, tools, checkpointer=memory)\n",
+    "\n",
+    "config = {\"configurable\": {\"thread_id\": \"abc123\"}}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "a13462d0-2d02-4474-921e-15a1ba1fa274",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "Hi, I'm Bob!\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Hello Bob! I'm an AI assistant who can help you search for information using specialized search tools. Is there anything specific you'd like to know about or search for? I'm happy to help you find accurate and up-to-date information on various topics.\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\"role\": \"user\", \"content\": \"Hi, I'm Bob!\"}\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "56d8028b-5dbc-40b2-86f5-ed60631d86a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What's my name?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Your name is Bob, as you introduced yourself earlier. I can remember information shared within our conversation without needing to search for it.\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_message = {\"role\": \"user\", \"content\": \"What's my name?\"}\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bda99754-0a11-4447-b408-e8db8f2e3517",
+   "metadata": {},
+   "source": [
+    "예 [Langsmith Trace] (https://smith.langchain.com/public/fa73960b-0f7d-4910-b73d-757a12f33b2b/r)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae908088",
+   "metadata": {},
+   "source": [
+    "새로운 대화를 시작하려면`thrable_id`를 변경하기 만하면됩니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "24460239",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "================================\u001b[1m Human Message \u001b[0m=================================\n",
+      "\n",
+      "What's my name?\n",
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "I apologize, but I don't have access to any tools that would tell me your name. I can only assist you with searching for publicly available information using the tavily_search function. I don't have access to personal information about users. If you'd like to tell me your name, I'll be happy to address you by it.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# highlight-next-line\n",
+    "config = {\"configurable\": {\"thread_id\": \"xyz123\"}}\n",
+    "\n",
+    "input_message = {\"role\": \"user\", \"content\": \"What's my name?\"}\n",
+    "for step in agent_executor.stream(\n",
+    "    {\"messages\": [input_message]}, config, stream_mode=\"values\"\n",
+    "):\n",
+    "    step[\"messages\"][-1].pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c029798f",
+   "metadata": {},
+   "source": [
+    "## 결론\n",
+    "\n",
+    "그것은 랩입니다!이 빠른 시작에서 우리는 간단한 에이전트를 만드는 방법을 다루었습니다.\n",
+    "그런 다음 중간 단계뿐만 아니라 토큰으로 응답을 되 찾는 방법을 보여주었습니다!\n",
+    "우리는 또한 메모리에 추가하여 대화를 나눌 수 있습니다.\n",
+    "에이전트는 배울 것이 많은 복잡한 주제입니다!\n",
+    "\n",
+    "에이전트에 대한 자세한 내용은 [langgraph] (/docs/concepts/architecture/#langgraph) 문서를 확인하십시오.여기에는 자체 개념, 튜토리얼 및 방법 안내서 세트가 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3ec3244",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/docs/tutorials/summarization_ko.ipynb
+++ b/docs/docs/tutorials/summarization_ko.ipynb
@@ -1,0 +1,696 @@
+{
+ "cells": [
+  {
+   "cell_type": "raw",
+   "id": "2aca8168-62ec-4bba-93f0-73da08cd1920",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "title: 텍스트 요약\n",
+    "sidebar_class_name: hidden\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf13f702",
+   "metadata": {},
+   "source": [
+    "# 텍스트 요약\n",
+    "\n",
+    ":::info\n",
+    "\n",
+    "이 튜토리얼에서는 기본 체인과 [LangGraph](https://langchain-ai.github.io/langgraph/)를 사용하여 텍스트 요약 방법을 보여줍니다.\n",
+    "\n",
+    "이 페이지의 [이전 버전](https://python.langchain.com/v0.1/docs/use_cases/summarization/)에서는 기존 체인인 [StuffDocumentsChain](/docs/versions/migrating_chains/stuff_docs_chain/), [MapReduceDocumentsChain](/docs/versions/migrating_chains/map_reduce_chain/), [RefineDocumentsChain](https://python.langchain.com/docs/versions/migrating_chains/refine_docs_chain/)을 소개했습니다. 이러한 추상화 사용 방법과 이 튜토리얼에서 설명하는 방법과의 비교는 [여기](/docs/versions/migrating_chains/)에서 확인할 수 있습니다.\n",
+    "\n",
+    ":::\n",
+    "\n",
+    "PDF, Notion 페이지, 고객 질문 등 여러 문서가 있고 그 내용을 요약하고 싶다고 가정해 봅시다. \n",
+    "\n",
+    "LLM은 텍스트를 이해하고 요약하는 능력이 뛰어나 이러한 작업에 적합합니다.\n",
+    "\n",
+    "[검색 증강 생성(RAG)](/docs/tutorials/rag) 맥락에서 텍스트를 요약하면 많은 수의 검색된 문서 정보를 압축해 LLM이 참고할 수 있는 문맥을 제공할 수 있습니다.\n",
+    "\n",
+    "이번 안내서에서는 여러 문서의 내용을 LLM으로 요약하는 방법을 살펴보겠습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e233997",
+   "metadata": {},
+   "source": [
+    "![Image description](../../static/img/summarization_use_case_1.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc8c5f87-3239-44e1-8772-a97cb6138cc5",
+   "metadata": {},
+   "source": [
+    "## 개념\n",
+    "\n",
+    "이번 튜토리얼에서 다룰 개념은 다음과 같습니다:\n",
+    "\n",
+    "- [언어 모델](/docs/concepts/chat_models) 사용하기.\n",
+    "\n",
+    "- [문서 로더](/docs/concepts/document_loaders) 사용하기. 특히 HTML 웹페이지에서 콘텐츠를 로드할 때 [WebBaseLoader](https://python.langchain.com/api_reference/community/document_loaders/langchain_community.document_loaders.web_base.WebBaseLoader.html)를 활용합니다.\n",
+    "\n",
+    "- 문서를 요약하거나 결합하는 두 가지 방법\n",
+    "  1. 문서를 단순히 하나의 프롬프트로 이어 붙이는 [Stuff](/docs/tutorials/summarization#stuff)\n",
+    "  2. 많은 문서를 처리하기 위한 [Map-reduce](/docs/tutorials/summarization#map-reduce) 방식. 문서를 여러 배치로 나눈 뒤 각 배치를 요약하고, 그 요약들을 다시 요약합니다.\n",
+    "\n",
+    "이러한 전략과 [반복 정제](/docs/how_to/summarize_refine) 등을 다루는 짧고 집중적인 가이드는 [How-to 가이드](/docs/how_to/#summarization)에서 확인할 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4715b4ff",
+   "metadata": {},
+   "source": [
+    "## 개요\n",
+    "\n",
+    "요약기를 만들 때 핵심 질문은 문서를 LLM의 컨텍스트 창에 어떻게 전달할 것인가입니다. 이를 위한 일반적인 두 가지 방법은 다음과 같습니다.\n",
+    "\n",
+    "1. `Stuff`: 모든 문서를 하나의 프롬프트에 그대로 \"채워 넣는\" 방식입니다. 가장 단순한 접근법이며, 이 방법에 사용되는 `create_stuff_documents_chain` 생성자에 대해서는 [여기](/docs/how_to/summarize_stuff/)를 참고하세요.\n",
+    "\n",
+    "2. `Map-reduce`: \"맵\" 단계에서 각 문서를 따로 요약한 뒤, 그 요약들을 \"리듀스\" 단계에서 최종 요약으로 합치는 방식입니다. 이 방법에 사용되는 `MapReduceDocumentsChain`에 대한 자세한 내용은 [여기](https://python.langchain.com/api_reference/langchain/chains/langchain.chains.combine_documents.map_reduce.MapReduceDocumentsChain.html)를 참고하세요.\n",
+    "\n",
+    "맵-리듀스는 개별 문서의 이해가 이전 맥락에 의존하지 않을 때 특히 효과적입니다. 예를 들어 짧은 문서가 많은 코퍼스를 요약할 때 유용합니다. 반대로 소설처럼 순서가 중요한 긴 텍스트를 요약할 때는 [반복 정제](/docs/how_to/summarize_refine)가 더 적합할 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08ec66bc",
+   "metadata": {},
+   "source": [
+    "![Image description](../../static/img/summarization_use_case_2.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bea785ac",
+   "metadata": {},
+   "source": [
+    "## 설정\n",
+    "\n",
+    "먼저 환경 변수를 설정하고 필요한 패키지를 설치합니다:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "928585ec-6f6f-4b67-b2c8-0fc87186342b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade --quiet tiktoken langchain langgraph beautifulsoup4 langchain-community\n",
+    "\n",
+    "# Set env var OPENAI_API_KEY or load from a .env file\n",
+    "# import dotenv\n",
+    "\n",
+    "# dotenv.load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d6276d52-d33f-4b6a-aae3-2682df9eb8a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ[\"LANGSMITH_TRACING\"] = \"true\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21541329-f883-42ca-bc94-ab9793951dfa",
+   "metadata": {},
+   "source": [
+    "먼저 문서를 불러옵니다. 블로그 글을 로드하기 위해 [WebBaseLoader](https://python.langchain.com/api_reference/community/document_loaders/langchain_community.document_loaders.web_base.WebBaseLoader.html)를 사용하겠습니다:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "23154e97-c4cb-4bcb-a742-f0c9d06639da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.document_loaders import WebBaseLoader\n",
+    "\n",
+    "loader = WebBaseLoader(\"https://lilianweng.github.io/posts/2023-06-23-agent/\")\n",
+    "docs = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22548ae0-7f67-4dd0-a3f8-d6675b38df53",
+   "metadata": {},
+   "source": [
+    "다음으로 사용할 LLM을 선택합니다:\n",
+    "\n",
+    "import ChatModelTabs from \"@theme/ChatModelTabs\";\n",
+    "\n",
+    "<ChatModelTabs\n",
+    "  customVarName=\"llm\"\n",
+    "/>\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b1c639d9-b27c-4e71-9312-d2666b05f1e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# | output: false\n",
+    "# | echo: false\n",
+    "\n",
+    "from langchain_openai import ChatOpenAI\n",
+    "\n",
+    "llm = ChatOpenAI(model=\"gpt-4o-mini\", temperature=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "615b36e1",
+   "metadata": {},
+   "source": [
+    "## Stuff: 한 번의 LLM 호출로 요약하기 {#stuff}\n",
+    "\n",
+    "다음과 같이 큰 컨텍스트 윈도우를 가진 모델을 사용할 때는 [create_stuff_documents_chain](https://python.langchain.com/api_reference/langchain/chains/langchain.chains.combine_documents.stuff.create_stuff_documents_chain.html)을 사용할 수 있습니다:\n",
+    "\n",
+    "* 128k 토큰 OpenAI `gpt-4o`\n",
+    "* 200k 토큰 Anthropic `claude-3-5-sonnet-20240620`\n",
+    "\n",
+    "이 체인은 문서 목록을 받아 모두 하나의 프롬프트에 삽입한 뒤 그 프롬프트를 LLM에 전달합니다:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ef45585d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The article \"LLM Powered Autonomous Agents\" by Lilian Weng discusses the development and capabilities of autonomous agents powered by large language models (LLMs). It outlines a system architecture that includes three main components: Planning, Memory, and Tool Use. \n",
+      "\n",
+      "1. **Planning** involves task decomposition, where complex tasks are broken down into manageable subgoals, and self-reflection, allowing agents to learn from past actions to improve future performance. Techniques like Chain of Thought (CoT) and Tree of Thoughts (ToT) are highlighted for enhancing reasoning and planning.\n",
+      "\n",
+      "2. **Memory** is categorized into short-term and long-term memory, with mechanisms for fast retrieval using Maximum Inner Product Search (MIPS) algorithms. This allows agents to retain and recall information effectively.\n",
+      "\n",
+      "3. **Tool Use** enables agents to interact with external APIs and tools, enhancing their capabilities beyond the limitations of their training data. Examples include MRKL systems and frameworks like HuggingGPT, which facilitate task planning and execution.\n",
+      "\n",
+      "The article also addresses challenges such as finite context length, difficulties in long-term planning, and the reliability of natural language interfaces. It concludes with case studies demonstrating the practical applications of these concepts in scientific discovery and interactive simulations. Overall, the article emphasizes the potential of LLMs as powerful problem solvers in autonomous agent systems.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain.chains.combine_documents import create_stuff_documents_chain\n",
+    "from langchain.chains.llm import LLMChain\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "\n",
+    "# Define prompt\n",
+    "prompt = ChatPromptTemplate.from_messages(\n",
+    "    [(\"system\", \"Write a concise summary of the following:\\\\n\\\\n{context}\")]\n",
+    ")\n",
+    "\n",
+    "# Instantiate chain\n",
+    "chain = create_stuff_documents_chain(llm, prompt)\n",
+    "\n",
+    "# Invoke chain\n",
+    "result = chain.invoke({\"context\": docs})\n",
+    "print(result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02d5a634-203c-4e43-ac55-4e502be095d3",
+   "metadata": {},
+   "source": [
+    "### 스트리밍\n",
+    "\n",
+    "결과를 토큰 단위로 스트리밍할 수도 있습니다:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ebc5b1ff-512f-4732-b385-b8829e069de8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|The| article| \"|LL|M| Powered| Autonomous| Agents|\"| by| Lil|ian| W|eng| discusses| the| development| and| capabilities| of| autonomous| agents| powered| by| large| language| models| (|LL|Ms|).| It| outlines| a| system| architecture| that| includes| three| main| components|:| Planning|,| Memory|,| and| Tool| Use|.| \n",
+      "\n",
+      "|1|.| **|Planning|**| involves| task| decomposition|,| where| complex| tasks| are| broken| down| into| manageable| sub|go|als|,| and| self|-ref|lection|,| allowing| agents| to| learn| from| past| actions| to| improve| future| performance|.| Techniques| like| Chain| of| Thought| (|Co|T|)| and| Tree| of| Thoughts| (|To|T|)| are| highlighted| for| enhancing| reasoning| and| planning|.\n",
+      "\n",
+      "|2|.| **|Memory|**| is| categorized| into| short|-term| and| long|-term| memory|,| with| mechanisms| for| fast| retrieval| using| Maximum| Inner| Product| Search| (|M|IPS|)| algorithms|.| This| allows| agents| to| retain| and| recall| information| effectively|.\n",
+      "\n",
+      "|3|.| **|Tool| Use|**| emphasizes| the| integration| of| external| APIs| and| tools| to| extend| the| capabilities| of| L|LM|s|,| enabling| them| to| perform| tasks| beyond| their| inherent| limitations|.| Examples| include| MR|KL| systems| and| frameworks| like| Hug|ging|GPT|,| which| facilitate| task| planning| and| execution|.\n",
+      "\n",
+      "|The| article| also| addresses| challenges| such| as| finite| context| length|,| difficulties| in| long|-term| planning|,| and| the| reliability| of| natural| language| interfaces|.| It| concludes| with| case| studies| demonstrating| the| practical| applications| of| L|LM|-powered| agents| in| scientific| discovery| and| interactive| simulations|.| Overall|,| the| piece| illustrates| the| potential| of| L|LM|s| as| general| problem| sol|vers| and| their| evolving| role| in| autonomous| systems|.||"
+     ]
+    }
+   ],
+   "source": [
+    "for token in chain.stream({\"context\": docs}):\n",
+    "    print(token, end=\"|\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e4e4a43",
+   "metadata": {},
+   "source": [
+    "### 더 깊이 들어가기\n",
+    "\n",
+    "* 프롬프트를 쉽게 커스터마이즈할 수 있습니다.\n",
+    "* `llm` 매개변수를 통해 [Claude](/docs/integrations/chat/anthropic)와 같은 다른 LLM을 간단히 시험해 볼 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad6cabee",
+   "metadata": {},
+   "source": [
+    "## Map-Reduce: 병렬화를 통한 긴 텍스트 요약 {#map-reduce}\n",
+    "\n",
+    "맵-리듀스 접근법을 살펴보겠습니다. 먼저 각 문서를 LLM을 이용해 개별 요약으로 \"맵\"한 다음, 그 요약들을 하나의 전역 요약으로 \"리듀스\"합니다.\n",
+    "\n",
+    "맵 단계는 보통 입력 문서 전체에 걸쳐 병렬로 수행됩니다.\n",
+    "\n",
+    "`langchain-core` 위에 구축된 [LangGraph](https://langchain-ai.github.io/langgraph/)는 [맵-리듀스](https://langchain-ai.github.io/langgraph/how-tos/map-reduce/) 워크플로를 지원하며, 이 문제에 적합합니다:\n",
+    "\n",
+    "- LangGraph는 각 단계(예: 연속 요약)를 스트리밍할 수 있어 실행 제어가 더 용이합니다.\n",
+    "- LangGraph의 [체크포인팅](https://langchain-ai.github.io/langgraph/how-tos/persistence/)은 오류 복구, 사람-중심 워크플로 확장, 대화형 애플리케이션 통합을 지원합니다.\n",
+    "- 아래에서 보겠지만 LangGraph 구현은 수정과 확장이 간단합니다.\n",
+    "\n",
+    "### Map\n",
+    "먼저 맵 단계에 사용할 프롬프트를 정의합니다. `stuff` 방식에서 사용한 요약 프롬프트를 그대로 사용할 수 있습니다:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a1e6773c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "\n",
+    "map_prompt = ChatPromptTemplate.from_messages(\n",
+    "    [(\"system\", \"Write a concise summary of the following:\\\\n\\\\n{context}\")]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "272ce8ce-919d-4ded-bbd5-a53a8a30bc66",
+   "metadata": {},
+   "source": [
+    "프롬프트를 저장하고 불러오기 위해 Prompt Hub를 사용할 수도 있습니다.\n",
+    "\n",
+    "이는 [LangSmith API 키](https://docs.smith.langchain.com/)와 함께 작동합니다.\n",
+    "\n",
+    "예를 들어 맵 프롬프트는 [여기](https://smith.langchain.com/hub/rlm/map-prompt)에서 확인할 수 있습니다.\n",
+    "\n",
+    "```python\n",
+    "from langchain import hub\n",
+    "\n",
+    "map_prompt = hub.pull(\"rlm/map-prompt\")\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bee3c331",
+   "metadata": {},
+   "source": [
+    "### Reduce\n",
+    "\n",
+    "맵 단계 결과를 하나의 출력으로 줄이기 위한 프롬프트도 정의합니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6a718890-99ab-439a-8f79-b9ae9c58ad24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Also available via the hub: `hub.pull(\"rlm/reduce-prompt\")`\n",
+    "reduce_template = \"\"\"\n",
+    "The following is a set of summaries:\n",
+    "{docs}\n",
+    "Take these and distill it into a final, consolidated summary\n",
+    "of the main themes.\n",
+    "\"\"\"\n",
+    "\n",
+    "reduce_prompt = ChatPromptTemplate([(\"human\", reduce_template)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d7df564-415a-49e2-80b6-743446b40be5",
+   "metadata": {},
+   "source": [
+    "### LangGraph로 오케스트레이션하기\n",
+    "\n",
+    "아래에서는 문서 목록을 요약한 뒤 위의 프롬프트를 사용해 이를 결합하는 간단한 애플리케이션을 구현합니다.\n",
+    "\n",
+    "맵-리듀스 흐름은 텍스트 길이가 LLM의 컨텍스트 창보다 길 때 특히 유용합니다. 긴 텍스트를 다룰 때는 리듀스 단계에서 요약할 컨텍스트가 모델의 컨텍스트 창 크기를 넘지 않도록 하는 메커니즘이 필요합니다. 여기서는 요약을 재귀적으로 \"축약\"하는 방법을 구현합니다: 입력을 토큰 제한에 따라 분할하고 각 분할에 대해 요약을 생성합니다. 이 과정을 전체 요약 길이가 원하는 한도 내에 들어올 때까지 반복하여 임의 길이의 텍스트를 요약할 수 있습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7821efb9-e1de-4234-84d2-75dfe13b5a6c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Created a chunk of size 1003, which is longer than the specified 1000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Generated 14 documents.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_text_splitters import CharacterTextSplitter\n",
+    "\n",
+    "text_splitter = CharacterTextSplitter.from_tiktoken_encoder(\n",
+    "    chunk_size=1000, chunk_overlap=0\n",
+    ")\n",
+    "split_docs = text_splitter.split_documents(docs)\n",
+    "print(f\"Generated {len(split_docs)} documents.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e7f1c8a-070e-47f0-bcf2-16d6191051ac",
+   "metadata": {},
+   "source": [
+    "다음으로 그래프를 정의합니다. 여기서는 \"축약\" 단계를 설명하기 위해 최대 토큰 길이를 1,000토큰으로 낮게 설정했습니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "10ced55c-9e3e-404f-abe9-83ac29ffaa5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import operator\n",
+    "from typing import Annotated, List, Literal, TypedDict\n",
+    "\n",
+    "from langchain.chains.combine_documents.reduce import (\n",
+    "    acollapse_docs,\n",
+    "    split_list_of_docs,\n",
+    ")\n",
+    "from langchain_core.documents import Document\n",
+    "from langgraph.constants import Send\n",
+    "from langgraph.graph import END, START, StateGraph\n",
+    "\n",
+    "token_max = 1000\n",
+    "\n",
+    "\n",
+    "def length_function(documents: List[Document]) -> int:\n",
+    "    \"\"\"Get number of tokens for input contents.\"\"\"\n",
+    "    return sum(llm.get_num_tokens(doc.page_content) for doc in documents)\n",
+    "\n",
+    "\n",
+    "# This will be the overall state of the main graph.\n",
+    "# It will contain the input document contents, corresponding\n",
+    "# summaries, and a final summary.\n",
+    "class OverallState(TypedDict):\n",
+    "    # Notice here we use the operator.add\n",
+    "    # This is because we want combine all the summaries we generate\n",
+    "    # from individual nodes back into one list - this is essentially\n",
+    "    # the \"reduce\" part\n",
+    "    contents: List[str]\n",
+    "    summaries: Annotated[list, operator.add]\n",
+    "    collapsed_summaries: List[Document]\n",
+    "    final_summary: str\n",
+    "\n",
+    "\n",
+    "# This will be the state of the node that we will \"map\" all\n",
+    "# documents to in order to generate summaries\n",
+    "class SummaryState(TypedDict):\n",
+    "    content: str\n",
+    "\n",
+    "\n",
+    "# Here we generate a summary, given a document\n",
+    "async def generate_summary(state: SummaryState):\n",
+    "    prompt = map_prompt.invoke(state[\"content\"])\n",
+    "    response = await llm.ainvoke(prompt)\n",
+    "    return {\"summaries\": [response.content]}\n",
+    "\n",
+    "\n",
+    "# Here we define the logic to map out over the documents\n",
+    "# We will use this an edge in the graph\n",
+    "def map_summaries(state: OverallState):\n",
+    "    # We will return a list of `Send` objects\n",
+    "    # Each `Send` object consists of the name of a node in the graph\n",
+    "    # as well as the state to send to that node\n",
+    "    return [\n",
+    "        Send(\"generate_summary\", {\"content\": content}) for content in state[\"contents\"]\n",
+    "    ]\n",
+    "\n",
+    "\n",
+    "def collect_summaries(state: OverallState):\n",
+    "    return {\n",
+    "        \"collapsed_summaries\": [Document(summary) for summary in state[\"summaries\"]]\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "async def _reduce(input: dict) -> str:\n",
+    "    prompt = reduce_prompt.invoke(input)\n",
+    "    response = await llm.ainvoke(prompt)\n",
+    "    return response.content\n",
+    "\n",
+    "\n",
+    "# Add node to collapse summaries\n",
+    "async def collapse_summaries(state: OverallState):\n",
+    "    doc_lists = split_list_of_docs(\n",
+    "        state[\"collapsed_summaries\"], length_function, token_max\n",
+    "    )\n",
+    "    results = []\n",
+    "    for doc_list in doc_lists:\n",
+    "        results.append(await acollapse_docs(doc_list, _reduce))\n",
+    "\n",
+    "    return {\"collapsed_summaries\": results}\n",
+    "\n",
+    "\n",
+    "# This represents a conditional edge in the graph that determines\n",
+    "# if we should collapse the summaries or not\n",
+    "def should_collapse(\n",
+    "    state: OverallState,\n",
+    ") -> Literal[\"collapse_summaries\", \"generate_final_summary\"]:\n",
+    "    num_tokens = length_function(state[\"collapsed_summaries\"])\n",
+    "    if num_tokens > token_max:\n",
+    "        return \"collapse_summaries\"\n",
+    "    else:\n",
+    "        return \"generate_final_summary\"\n",
+    "\n",
+    "\n",
+    "# Here we will generate the final summary\n",
+    "async def generate_final_summary(state: OverallState):\n",
+    "    response = await _reduce(state[\"collapsed_summaries\"])\n",
+    "    return {\"final_summary\": response}\n",
+    "\n",
+    "\n",
+    "# Construct the graph\n",
+    "# Nodes:\n",
+    "graph = StateGraph(OverallState)\n",
+    "graph.add_node(\"generate_summary\", generate_summary)  # same as before\n",
+    "graph.add_node(\"collect_summaries\", collect_summaries)\n",
+    "graph.add_node(\"collapse_summaries\", collapse_summaries)\n",
+    "graph.add_node(\"generate_final_summary\", generate_final_summary)\n",
+    "\n",
+    "# Edges:\n",
+    "graph.add_conditional_edges(START, map_summaries, [\"generate_summary\"])\n",
+    "graph.add_edge(\"generate_summary\", \"collect_summaries\")\n",
+    "graph.add_conditional_edges(\"collect_summaries\", should_collapse)\n",
+    "graph.add_conditional_edges(\"collapse_summaries\", should_collapse)\n",
+    "graph.add_edge(\"generate_final_summary\", END)\n",
+    "\n",
+    "app = graph.compile()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f00af5d5-bfac-4c13-9439-aa0b18ac3b44",
+   "metadata": {},
+   "source": [
+    "LangGraph는 그래프 구조를 시각화할 수 있어 동작을 이해하는 데 도움이 됩니다:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "0c8d41e4-664d-46f4-94e9-248971d428a6",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/jpeg": "/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDAAMCAgMCAgMDAwMEAwMEBQgFBQQEBQoHBwYIDAoMDAsKCwsNDhIQDQ4RDgsLEBYQERMUFRUVDA8XGBYUGBIUFRT/2wBDAQMEBAUEBQkFBQkUDQsNFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBT/wAARCAHXARsDASIAAhEBAxEB/8QAHQABAAMAAwEBAQAAAAAAAAAAAAUGBwMECAECCf/EAFcQAAEEAQIDAggHCgoJAwMFAAEAAgMEBQYRBxIhEzEIFBYiQVFWlBUXVZOV0dMyQlJTVGGBs9LUCSM3OHF1dpKhtDM0NmJygpGxsiQ1dCZEw3ODheHw/8QAGgEBAQEBAQEBAAAAAAAAAAAAAAECBAMFB//EADMRAQABAgIHBQcFAQEAAAAAAAABAhEDkRIUIVFSYdEEEzFToSNBcbHB0uEVM4Gi8EIy/9oADAMBAAIRAxEAPwD+qaIiAiIgIiICIuhmsxFhaYmfHJYle9sUNaAAyTSOPRjQSB6ySSA0AuJABIsRNU2gd9R02o8TXeWS5SlE8fevsMB/xKifI92dHballGQc4f8At0TnClEN/ueXp2p9Bc/v6kNYDyqRj0jgoW8seFxzG777Nqxgb/8ARe+jhU7Kpmfh/vo1sffKrCfLFD3pn1p5VYT5Yoe9M+tffJbC/JFD3Zn1J5LYX5Ioe7M+pPY8/Q2PnlVhPlih70z608qsJ8sUPemfWvvkthfkih7sz6k8lsL8kUPdmfUnsefobHzyqwnyxQ96Z9aeVWE+WKHvTPrX3yWwvyRQ92Z9SeS2F+SKHuzPqT2PP0Nj9RakxE7w2LKUpHH71lhhP/dSSiZNJYKZhZJhce9h6lrqsZH/AGUb5Eswn8dpmb4Hkb18RBJpS/7pi7o/+KPlI6b8wHKWjhVbImY+Ph/v4TYtCKOwmZZma0jjDJVswvMVirLtzwvHoO3QggggjoQQR3qRXjVTNM2lBERZBERAREQEREBERAREQEREBERAREQEREBERAVYrbZfX9x79nQ4etHFC0+iabd0jvVvyNiAPeOZ46bnezqsYUeJ651JXfuDajrXozt0cOQxOAPrBiG//EPWujC8K599vrEfK6x71nRdTK5ajgsbZyGSuV8fQrMMs9q1K2KKJg73Oe4gNA9ZKpQ8IThYe7iXo8//AM9V+0XOi/Pe2NjnuIa1o3JPoCxat4SsWqOHGpNVaa0hqSanRxU+Sxt29Sjjq5FrNwHRntgeXccxa/kcWgkDdW6vx84ZXJ469biLpOzZlcI4oYs5Vc+RxOwa0CTqSdgAse0Dwo1jNntXVa+lH8M9H5nT9unYwUmYjv035OZ2zbFWOMnsWBpfzbBnNu3zNxugv+h+N+Vy3BrB6tyehdTz5K3BVacfj6kEstt8kDXmeFrZy1sBJOxkcwj0gdN/tnwn9K0eHdrV9rH5ytXpZiPBX8ZJSHj9K2+RjOSSIO67dox3mF27XDl5j0Wb3NHcSc9wd0FpvKaEtNraYnpVczga+crM+H6sVZ8RMcjZABGJBFIYpSzmA2Pd1isHwK1fQ0tqLFVtEVdP1bmvsPqSljqV6u+GGkx9Xtm/dNAfGIHFzQNiXbML+9Bf9aeEVqTA624e42pw41IaudkvizRmip+OyCGEuYIv/Vhjeuz3c5Hmjp16LemO5mNcWlpI35T3hZLxr01qZ+tOHOsdNYPymk03cueNYmO3FWmlisVnRc7HylrN2O5SQSNweinDx84d0ia+W11pbD5SL+Lt461naglqzDo+J47T7prt2n84KDQEVBf4QPC6JwD+JOkGEgO2dnao6Ebg/wCk9IIKuWIzFDUGMr5HF3q2Sx9lnaQW6crZYpW/hNe0kOH5wUEJktsRrrEWWbNZlo5KE46+fJGx00TvV0a2cfn5h6lZ1WNRt8c1bpOqwEugnnyD9huAxkD4ep9HnWG/07H86s66MX/zRPL6z9Fn3CIi50EREBERAREQEREBERAREQEREBERAREQEREBQuoMTPZmp5LHiP4VolwiEri1ksT9u0icR3B3K0g9dnMYdiAQZpFqmqaJvB4IzEZylqGCQRbtmj82xTsN5ZoHfgyM9Hcdj3EdQSCCu18G1PyWD5sfUulmtLYvPyRy3K29mNpbHbgkdDPGCdyGysIe0b7HYHboFHO0PICez1LnYm778otMd/i5hP8AivbRwqtsVW+PX8LsT4x1RpBFaEEdQRGF2FVvIif2pz3z8X2SeRE/tTnvn4vsk7vD4/SVtG9aUVF1LojOeTmV+AtU5b4b8Ul8R8bnj7HxjkPZ8+0W/Lzcu+3o3XX0ZojUnklh/KfVOT8ovFI/hHxCePxfxjlHadnvFvy82+2/oTu8Pj9JLRvaEuu7H1XuLnVoXOJ3JMY3Kr3kRP7U575+L7JPIif2pz3z8X2Sd3h8fpJaN6wfBtT8lg+bH1Lq5fOUNOVojYkbG6Q8letEN5Z3fgRsHVx/MO7vOwBKihoiQjaTUudkbvvsbLG/4tYD/ipDC6TxeBmknq13OtyDlfbsyvnnePUZHku2/Nvt+ZNHCp2zVf4R9Z6SbHHgMVYbbtZfJMYzJW2tj7JjuZteFpJZGD6T5xLiO8n1AKcRF5V1TXN5SdoiIsIIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIK7xGrY65w91RBl70mMxMuLtMuXofu68JicJJG9D1a3cjoe7uXR4P08Pj+FWkaun8nNmsHDi67KORsb9pZhEYDJHbgdXDY9w7+5SOv7MNPQmpLFjEnPQRY2zJJimt5jdaInEwAbHfnHm7bH7ruK6fCm5XyPDPS1qpgHaWrTY2vJFhHs5DQaYwRCW7Dbk+522Hd3ILWiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIInVseWm0rmY8BLFBnXUpm4+WcbxssFh7Iu3B80P5Seh6ehdfQUOfr6JwUWq54LOpmUom5KaqAIn2OUdoWbADYu326D+hcfEatjrnD3VEGXvSYzEy4u0y5eh+7rwmJwkkb0PVrdyOh7u5dHg/Tw+P4VaRq6fyc2awcOLrso5Gxv2lmERgMkduB1cNj3Dv7kFwREQEREBERAREQEREBERAREQEREBERAREQEREBERARFD6h1CMKK8MMBuZC04tgrB3ICBtzPc7Y8rGgjc7HvAAJIB1TTNc6NPiJhFSTnNXk7ihhAPUbUx2/T2fVfPhzWH5Dg/epvs11arXvjOFsu6KkfDmsPyHB+9TfZp8Oaw/IcH71N9mmq174zgsu6KkfDmsPyHB+9TfZp8Oaw/IcH71N9mmq174zgsu6KkfDmsPyHB+9TfZp8Oaw/IcH71N9mmq174zgs8Hfwo3Ax2N1Di+KOMrk1skGY7Llo35Z2N2hkP8AxRt5N+4dk30uUZ/BdcFJM/r7JcSrsbmUMCx9LHu6gSW5Yy2Qg+kMieQQfxzT6F7Y4r6RzfF/h5nNH5rH4TxDKVzEZG2ZS6F4IdHI3ePbmY8NcN+m7eq6vBjQeb4I8NsLo7DU8LLVx8ZD7MliUPsSuJdJI7aPvc4np12Gw7gmq174zgs21FSPhzWH5Dg/epvs0+HNYfkOD96m+zTVa98ZwWXdFSPhzWH5Dg/epvs0+HNYfkOD96m+zTVa98ZwWXdFSPhzWH5Dg/epvs0+HNYfkOD96m+zTVa98ZwWXdFSPhzWH5Dg/epvs0+HNYD/AOxwZ/N41MP/AMaarXvjOCy7ooTTuo3Zh1irareI5OsGmauH9owtdvyvY/YczTykb7AggggembXNXRVROjV4oIiLAIiICIiAiIgIiICIiAiIgKlaiO/EbCj0DFXdvzfx1X/+v+iuqpOov5R8N/VNz9dWXZ2X9z+J+UtQk0WTceNcZbTF7RGHx+bh0nV1BlH07mo54Y5BTayCSVrGiUGMPlcwMaXggdehOyyOnxw13W0XXoVcna1Rm83rK9g8dnaVKoTLRrxFxmrROdFC5x7JwHO8t5jIRzANavSaoibMvWqLyzkeIPGDTuCfWyBv4sWdQ4bH4zN5/H0PGZWWZzFYjlhrSvjIZ5hDm8hPMR023Xc1fxl1hwfHErEXMm7WF7FV8RPhrlqpBDKH3p31yyVsXZxuDHsDh9zvvyl3pTSgemkXmevrLi9prF6ss5KDOy4mvprIXWZXUFDF15aV6KIvh7NtWaRsjHedu17NwWt85wJUrNqTVen+DGGz+e4iXxn9Sx49tOHGYKrYeyxIwvNerDyDne8Hq6Vzmt7Mu2aNwGkPQMkjIY3SSOaxjRu5zjsAPWSv0vGevNZ6u1t4N/FzD6kv5CrlNNZKtXNi1SqwWrNeQV5WMnjiMkTXDtfuoyNw1vd5wOkcTdZ630jn9JcPcJlc7nsxdp28nezlOhjn5B0McjGsYyOUw1h1lALuUkBo80klwaQ9CIs74I5XW2T03kGa5x1mnerX3xU7FyOvFPbq8rHMkljgkkjY/mL2kNdseQHYb7Lq+EBmNY4PSWOs6Q8cjAyUTctaxlJl27Wo8r+0kggeC2Rwd2e42ceUuIaSrfZcaciw7RHEy/nOIPD3HUdWs1Vp/K6dyV6e+ylHB43NDYrsY9zQ0GNzA97HMHKN992gjYVKrxP11qPUmGwdXU3wYclrvUGDfbbQglfFTqxzPiYwOZtzNEYAc4Hr1dz9xmlA9PIvJ8/EHiXp7RmuNT2dc/CTdFanGH8RkxNaNmTriWvzOnc1u7ZOWxsDFyAcg3B3O3e4i8QuIVOrxqzuK1h8G1dD3I3UMb8GV5Y52eJ15nxzPc3mLSXu25S1wLju4jlDWkPUSLA4ddak0DrrKYbVOtY72Jm0dY1GMraxsMXwZLDKyN/KyIN549pQ4MdzO8zbmO6qejOMGu6eos5isnkM1kKNrSN3P4vIZ/DVKE7JYXMAdHHC47xkSg8szQ8Fo33BKaUD1Qi82VNW8QtM8E9I8TsxrGXMRSR4rJ5rGMx1aOBlCVgFgsLY+fna2Zkrjzbbwu5Q1ruVaZwv1bldcav19fdcEmlqOSZh8TXbGwAyQMHjU3OBzODpXlg3JA7HoBud7FVxc8OduJUw9eIbv+f+OO3/AHP/AFV3VHw/8pc39UD9cVeF5dq/9x8IakREXGyIiICIiAiIgIiICIiAiIgKk6i/lHw39U3P11ZXZVbVuLtNyePzdOu646pFLWnqx7do6KQscXM373NdG3zdxuC7bchoPV2aYjE27p+UrDK/CQ0Tktc6RxlTG4nKZowZBtiWrisjUqyFoY8AltuN8MoBIIa8DY7OBBaFAaH4NZ3WXDiTC8Rpb9OSllW3dOzQ264ymKYxjRG4zVo2xdoHGXblaRyuAO/o1t2sYGHZ2KzoO3UDDWjt+kR7L55Z1/krPfQlv7NdncVzN9GV0ZVb4j6NrBVMbldTakzrq+aqZ1tzJ3I5JjNXex8bOkYY2MmMbtY1u+5O4J3XZ1LwR0zrDJ6rt5mKxfj1Ljq2MvVHyARCOB8j43R7AOa8OlJ5uY7FrSNtutg8s6/yVnvoS39mnlnX+Ss99CW/s1e4r4TRncq2K4JQUtP5/EZDWGq9RVsxjpMW92YyDJXV4Xtc0mMCNrefZx89wc47Dcld3UnB7Eak0bp7T7r2Sx50++vNjMpRmYy3WlhjMbJA4sLCSxzmkFhaQ49FOeWdf5Kz30Jb+zTyzr/JWe+hLf2adxXwyaM7lKpeDnpqDCa0xVy/mczW1fHGMq7I3BJI+VjC3tmODQWvI5Og80dmzla0Ag/cl4PuPy+Nwrbmq9UTZ7DTSS0NTeOxNyUDZGhskXOIgx0bg0btcw77b96unlnX+Ss99CW/s08s6/yVnvoS39mncV8MmjO5ANxmrNBYehi9NVG6zY0ySWMhqjUEkFkvc/m721pA4dT0AaGgAAbd3Xuaf1dxFx5qahdNoF1Wdlird0jnzYmldyva5kglqMbybOB5SHAnY9C0FT+Q4hY3FULN27TzNSnWidNPYnw9pkcUbQS5znGPYAAEknuAX4xPEnE57GVcjja2XyGPtxNmr2q2IsyRTRuG7XNcIyHAjqCE7jE4ZTRlUofBw09jcVpqvh8tnMFfwJteL5elaYbcosv57ImMkb2P7R+zju3oQOXlXNpXwd9OaRt4KzUyGYsS4fM3s5A65ZbK6Se3E+OUSOLOZzQJHEdebfYlzuu9y8s6/wAlZ76Et/Zp5Z1/krPfQlv7NO4r4V0Z3KvkuBGAymlNY6fluZJtLVOWOYuyMljEkcxMJ5YyWbBn8Qzo4OPV3Xu2/eZ4HYHOYfiFjZ7eRZBrd4kyLo5Iw6I9hHB/E7sIb5sbT5wd1J9HRWXyzr/JWe+hLf2aeWdf5Kz30Jb+zTuK+E0Z3IHVXBbTutMzPkMt41ZFjT9jTUtXtA2J9WaSN73dG8wkBibs4OAHXpvsRA0fBvxMGUjydzVOqMzkWYuzhjZyN2KQupzMDTEWiINHKWh4cAHFwHMXDor55Z1/krPfQlv7NPLOv8lZ76Et/Zp3FfCmjO5WdWaVt6a4LN0dprBv1U2PFswUVW7bjg5oOx7HtJpCACA0Au5W7nc7NUnwc4dw8J+GGnNJxPbM7GVGxzzM32lnO7pZBv186Rz3dfWpPyzr/JWe+hLf2aeWVc92KzxP9S2h/wDjTuMTx0ZXRnc7WH/lLm/qgfrirwqppXG2rOYtZ23WkoiWuyrXrTbdqGBznOe8DflLiRs3fcBoJ2JLRa1x9pmJrtHuiEkREXIgiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIKNx1/kR4hf2dyP8AlpFEeC7/ADcOGX9naP6lql+Ov8iPEL+zuR/y0iiPBd/m4cMv7O0f1LUGoIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiCjcdf5EeIX9ncj/AJaRRHgu/wA3Dhl/Z2j+papfjr/IjxC/s7kf8tIojwXf5uHDL+ztH9S1BqCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAi432Io3cr5WMPqc4BfnxyD8fH/AHwraRzIuHxyD8fH/fCeOQfj4/74S0jmRcPjkH4+P++E8cg/Hx/3wlpHMi4fHIPx8f8AfCeOQfj4/wC+EtI8Y+Gp4ZGR4RZPUvDa3oA3KmbwskdPOfC3Zh8c8Lo3P7LsD1Y/nHLz9eUHcc3SM8BzwxrvEG5ozhJV0E+OviMOIbeeblecRxV4eUSmHsRsHydmzbn6GQdTt1vn8IXwVg4t8Fpc3jgyXUWlee/AGEF0tcgeMR/3Wh49O8ew+6UT/BwcE4eGnCN+rcoyOLPaq5Z2CQgPhpN/0Le/pz7mQ7d4czfq1LSPYKLh8cg/Hx/3wnjkH4+P++EtI5kXD45B+Pj/AL4TxyD8fH/fCWkcyLh8cg/Hx/3wnjkH4+P++EtI5kXD45B+Pj/vhfplmKRwa2VjnH0BwJS0jkREUBERAREQEREBERAREQEREBERAVa15kbFHF1IK0zq0l+5FUM0Z2exrty4tOx2dytIB9BO6sqqHEb/AEWnv63h/wDCRdPZoicWmJWPFFt4faYA87T2Mld6XzVGSPcfWXOBJP5yd19+L7S3s3iPcIv2VLZLJVMNjrN+/Zip0qsbpp7E7wyOJjRu5znHoAACSSqPp/j9oLU1HJ3aOeDaWNq+O2bVypPVibB+Na+VjQ9n+80kFd/f4nHOZed6xfF9pb2bxHuEX7KfF9pb2bxHuEX7KplnwgNN53Q+ssppLJR38tgcRPkxSv1J6ziGxPfG8xytje6NxZtzN6H0FceL4rZa7q7hZipK9IV9U6ftZW65rH88csUdVzWxHm2Dd537hwcejeo67zWMTjnMvO9d/i+0t7N4j3CL9lPi+0t7N4j3CL9lV6Dj3oKzqluno9QxOyT7Rosd2EwrPsAkGFtgs7J0m4I5A8ncbbb9FyXuOmh8frA6XkzfaZptiOpJDWqTzRwzPIDI5JWMMcbySPNc4HqE7/E45zLzvTvxfaW9m8R7hF+ynxfaW9m8R7hF+yqbwy49YviPrLVmnIqV6nbw2SlpQvfRsiOeOOOJzpHSuibHG7mkcBGXcxDQ4bhwK02zZhpVpbFiVkEETDJJLI4NaxoG5JJ7gB6VYx8SfCucy870J8X2lvZvEe4Rfsp8X2lvZvEe4RfsqrY3wieH2W09lc5Vzr34nGNhfZtOx9pjQyZ/ZxPYHRgyNc7oHMDh0J32Vh1HxK03pLI2qOWyPilqriLGdmj7CR/LSgLRNLu1pB5S9vmjzjv0BTv8TjnMvO92Pi+0t7N4j3CL9lPi+0t7N4j3CL9lUxvhO8Nn2hWj1BLLZki7evDFi7b33I/w64ERNhvp3i5gACe4KTt8etB0sLgcs7Pslo55spxjq1aad9sx7c7GMYwuLwTtybc24I23B2nf4nHOZed6wfF9pb2bxHuEX7KfF9pb2bxHuEX7KqGI8JXhvnbVCClqQSuu2RSje6lZZGywXFogle6MNhlJGwjkLXHcbDqFI5TjtobCaybpW/nPFc0bEdTklqTiETSAGOMz8nZB7g5uzS/c7j1p3+JxzmXnenvi+0t7N4j3CL9lPi+0t7N4j3CL9lQ1/jXo7HaysaTkyc0uoq8sMU1Ctj7M74jK1ro3OMcbg1hD27vJ5RvsSCoLSnHjBWtD5PVebzlBmIjzNjHVJKtK3DKQ1/LHA6CVgldY23DmsYRuDsNgU7/E45zLzvXb4vtLezeI9wi/ZTyA0wAeXTuKYT98ynG0jruNiBuOoBVbHhA6AOlp9QHULG46C2yhIx1acWW2XdWQmsWdtzuHUN5NyOoGyt2ltUYzWeCq5nD2HWcfZ5uzkfC+JxLXFjgWPAc0hzSCCAeivf4k/wDc5l53pHQd6eerlKE877Rxl11Rk0ri+RzOzjlaHuPVxAlDeY7k8oJJJJNnVO4e/wCv6w/rgf5OqriuDtMRGLNuXrEE+IiIuZBERAREQEREBERAREQEREBVDiN/otPf1vD/AOEit6qPEVhNbBP+8jy0BcfVuHNH+LgP0rq7N+9SseKgeEfozK8QOCmp8HhIW2snYiikiqveGCz2c0crodz0HaNY5nXp53XoqHxP1DkOOHCjM4XB6I1RQvVPE8i6jm8YaUdrsLUUr6jXPOz3ObG4Dl3YenndV6GRe8xdHmfUuPznG7WefzOH0xmsHQg0Pk8GJM9SdRlu27RaY4Wsk2JYzkJL/ud3dCe9cmFhzc2W4EZx2mc/Tr1MLe09kGvouFjG2JGVo2SSx97Yuau89p9ztyu7iF6URTRHkDg9wyoUsLpzQms9KcRJc3jLbWTyMyF9+Bc6KUyRWmu7YQchLWP5QOYOP3PTdX3g9nMlwkdk9FZnRupbeSn1DctR5nHY11indis2XSNsyTg8rC1jwHteQ4CPoD0C9BIkU2GLcLZ7+juLPETAZLA5hrc9nnZihloqL3498LqcLSHTjzWPDoXN5XbEkt233Wt52GCxhMhFaqOyFZ9eRstRjeZ07C0gsA6blw3G3518z2AxmqcTYxeYoVspjbAAmqW4hJFIAQ4czT0OxAP6FVsRwM4dYDJ1sjjdDafoX6zxLBZrY2JkkTx3Oa4N3B/OFbTGwecJdPax1Bwx13o/TOG1VNomriac2Go6ro+LXq9mKy176UDnbOmjEUY5S7m2OzQ4hTvEi3l+J2sNU5LFaQ1PXx54Y5vGwzZDETV3T25HwlsDGOHMXnboNvO68vMASvVSLOiMNxunMpHxO4K2nYu42rj9K361uc13hlaV0dINjkdtsxx5H7NOxPK71FUrhpozPY/WHDKWzgsjWr0dSatmnfLUkYyvFM+YwvcSNmtfzDlJ2DtxtvuvU6K6I8sZ3Rmel4K8TqcWCyL79riJ4/VrspyGWaD4Wqv7aNu27mcjXO5x05QTvsCq/wAbMbrHVcevKeSxGustmoMzDNhaWJilbhm42GaGVsnmERzylrZCWu55OflDWjYFex0Umm4yfhphLdXjfxcy8+Os1qmSfiPFbc9d0bbDWU9nBjnAc3K4kEDuO4OxWI5fhvqJjK+fsYLUljF4jiHqC9cx+FknqZGSpZfIyK1XMbmSPDeYHzDu5j3bbglexkVmm48y29EaLs6HymdbpPibFYuZeo4XpfHLOahmrseYLkcc0j5WsZ2j2dW7ncgsLdita4E5TVmY4cUrOs4Z4sx207GPt1m1rE1dsrhBLNC3pHI6MNLmjuJ7h3LQEViLDo8Pf9f1h/XA/wAnVVxVQ4fMItark72S5fdp2PXarXYf8WkfoVvXh2n92fhHyhZERFyoIiICIiAiIgIiICIiAiIgLr5DH1srSmqXIWWK0zeV8bxuCP8A/eldhFYmYm8Cnu4f2mHlg1dnIIh9zHy1JOUermfA5x/pJJ/OvnkBf9s838zR/dlcUXTrOLyyjo1eVO8gL/tnm/maP7snkBf9s838zR/dlcV+ZHiONzyCQ0EkNBJ/QB1Kazicso6F5VDyAv8Atnm/maP7ss1uZqzrDK610foDiFen13p2CJ0jctj4DQimeSRHI9lZpJ2HXlPTmB67OAm6+Ty3hEaOxOU09lNT8M6MGZ7SbxrHsht5KrEdwGCTcxxyO5TuR1Ac0tIK1uKrDXlnkihjjkncHyvY0AyODQ0Fx9J5WtG59AA9Ca1icso6F5UbDcPM/FiqjMrrrJWsk2JoszU6dOGF8m3nFjHQvLW79wLifzru+QF/2zzfzNH92VxRNZxOWUdC8qd5AX/bPN/M0f3ZPIC/7Z5v5mj+7K4oms4nLKOheVO8gL/tnm/maP7suvkeHuakoWWUdcZWvddG4QS2KlOWNj9vNLmCBpcAdtwHDf1jvV5RNZxOWUdC8sAr5q/oGXRWnOJfEO1X1nqWaatWdhcdCKEsrXjkY1z67i0lr2bcxG7ubbZad5AX/bPN/M0f3ZWyerDZdE6aGOV0L+0jL2gljtiOYb9x2JG49ZWUZC9mOAGmdWajzeV1JxHxc2TFuvQrUY5beNryOHaNHLymSNhLndw5WtAA6EprOJyyjoXla/IC/wC2eb+Zo/uyeQF/2zzfzNH92VsqWW3KsNhjZGMlY17WyxujeARvs5rgC0+sEAj0rlTWcTllHQvKneQF/wBs838zR/dl+maBt77S6uzczD3sLKjN+vrbACP0FW9E1nE5ZR0Ly6mLxdXC0IaVKEQVohs1gJPedyST1JJJJJ3JJJJJK7aIuaZmZvLIiIoCIiAiIgIiICIiAiIgIiICIiAiKl8Y9Q6o0pw4y+W0ZhW6i1JW7F1XFvBIsAzMEjehBB7MvIO/QjfY9xDu8QNYWtJ6TzmRw2Gn1XmsdXbPHgqErRYnLjs0de4HZx32JIY7YOI2NdxXDp+rNX6S4i6idlsRqGhiex8m48kX0KliVp7Zxaw8sjwHFnNvykNadtwCJnR/DDTmktR5/U+OxQq6g1G+OfJ2nyvkke5rQAwFxPK0dTyt2G57u7a4ICIiAiIgIiICIiAiIgz/ACfDZmI4g5biNibGXu5yXDOpHA/CJZRuvZ50J5Heax4PM0O6NHaOJG5JMjw01rkdX6Ow2R1FgJ9HZ662QS4O9Mx0rHscWu5SPumnbmB2B5SCQFb1U9Y8LdM69zWm8vmsaLOU07b8dxltkr4pK8nTfZzSN2nYbtO4Ow3HRBbEVH4M6k1Xq3QVXJ61wTdN5+WxYbJjWgjso2zPbEepO5LA07+nfuCvCAiIgIiICIiAiIgIiICIiAiIgIiICIiAqRxqxmZzPDDOU9P6nh0ZmJWRivnLDg1lUiVhJJPraC3/AJld1mHhMeR3xHao+MDxzyQ7OHx/xDftuXt4+Tl26/d8n6N0GlVWubWhD3iV4YA54++O3euVcFHs/Eq/Y79j2beTfv5dun+C50BERAREQEREBERAREQEReEf4Ufgi/P6TxHEzHRF9rCAY7JbdSar3kxP/oZK9w//AHvzIPWXBDFZvC8OqNTUOq4da5Vs1gyZmu4OZK0zPLWgj8BpDP8AlV8X8dv4P7gvPxW4+4rKStkZhtKSR5izMzoDMx4NePf1ukaHbelsb1/YlAREQEREBERAREQEREBERAREQEREBERAVI41ZPM4bhhnLmn9MQ6zzETIzXwdhocy0TKwEEH1NJd/yq7qkcasZmczwwzlPT+p4dGZiVkYr5yw4NZVIlYSST62gt/5kFyquc6tCXsETywFzB96du5cq4qrXNrQh7xK8MAc8ffHbvXKgIiIK3mtV2K199DE48ZO3CAZ3Sz9hBDuAQ1z+VxLiDvytadhsTtu3eO8qNW+zmH+mpf3VdXTp5srqgnv+Fngn0naKID/AAAH6FOL6uhh4dqZoifDfu5TDWyEb5Uat9nMP9NS/uqeVGrfZzD/AE1L+6qSXTOZx7cu3Em9WGUdAbTaJmb25hDg0yBm/NyBxA5tttyAnsvLjOrqX5OHyo1b7OYf6al/dU8qNW+zmH+mpf3Vc2IzOP1Bjochi71bJUJwTFapzNlikAJB5XNJB6gjofQu4nsvLjOrqX5I3yo1b7OYf6al/dU8qNW+zmH+mpf3VSSJbC8uP7dS/JG+VGrfZzD/AE1L+6qL1Q/O6y05k8FltKYW3jMlWkqWYXZuXz43tLXD/Veh2Pf6FZkS2F5cf26l+TDfBi4LZjwZ9CWMDRxeIzF65bfauZN+TkhdMe6NvJ4u7ZrWgDbmPUuPTm2GweVGrfZzD/TUv7qpJEtheXH9upfkjfKjVvs5h/pqX91Tyo1b7OYf6al/dVJIlsLy4/t1L8kb5Uat9nMP9NS/uqeVGrfZzD/TUv7qpJEtheXH9upfkjfKjVvs5h/pqX91Tyo1b7OYf6al/dV2clkqeGx9i/kLUFGjWjMs9mzII4omAblznOIDQB3krnilZPEyWJ7ZI3tDmvYdw4HuIPpCey8uM6upfkj/ACo1b7OYf6al/dV+ma1y+P8A47NYOvVoN/0tihedaMQ/CcwxMPKPSRvsOuykF08y0Ow94OAcDBICCNwfNKsU4VU20IznqXjcZfi/orCaQy2qbGp8bJp/EyCG9fqTizHXkJYAx3Z8xDt5Gebtv5w9aiMtx0wVE6Dkx+OzmoqWszG7HXcNjnzwxRP7LaawTsYWATNcS4bgB3TzSF2+FOgNNaa4fY+ti8BjqFfIwQ3bkUFZjW2J3MYTJINvOduB1PqHqV6a0MaGtAa0DYADYAL5ldOjVNO5mVKxms9TX+JWd0/NomzS07QqiWrqeW7GYbsxEZ7JsI88bc793HpvGR6QqjW4z6j0HpzT9jinpmPEZXO6hiwVZmn5hcrw9q0dlLM9xBa0uEgJAO2zfWtkUFro51ujc2/SzKsmpY6cz8Yy43eF1kMPZtd1bsC7Yb7jbdYE6ih9HTZmxpPDSairw1c+6nCchDXfzxMscg7QMPpbzb7fmUwgIiICIiAsw8JjyO+I7VHxgeOeSHZw+P8AiG/bcvbx8nLt1+75P0brT1SONWTzOG4YZy5p/TEOs8xEyM18HYaHMtEysBBB9TSXf8qC4Uez8Sr9jv2PZt5N+/l26f4LnXFVc51aEvYInlgLmD707dy5UBERBQNOf+6ao/raT9VEs0zGc1jxE4v6l0lp3U/kZi9MUqctm1BQhtWbliyJHtH8cHNbG1sfXZvMST1Gy0vTn/umqP62k/VRKsa04KY3Vuqm6lp5zPaUzrqwpWLun7bIXW4GklrJWvY9ruUuds7YOG52K+ti+OXyWfFSZ8pxC1xr3V2msNrSPTbdHUqML7TMXBMcpdmr9s6SUSBwjhA5Ryx7Hcu87oFC8INey8UOMmhdV2K7atnK8N5bE0Me/K2Tx+AP5d+vLzA7b+jZX/UXg8YjO2zag1JqfCW7GOhxeRsYzIhkmUgiaWs8Zc9ji54DnDtG8r/OPnKYg4Ladx2f0llsSbmEm01Rdi6sNCflimpkN/iJmuB52Asa4dQeYb7rwtKML4f6su4DwZOGGPw+oMnh87lJbEVWrhMVDkLt0Nkmc9kbJj2bA0bOdI/zQBt0Lguzj+L2vtQ8PtI1nZiTBail1/JpTIZB2PrmaSBjLB3dD58bJCGR78hIDmnYlp2Ok1/Bm0/jcbjamKz2osQ/FZCzexVqpcjMuPbYbtNWi543DsXd/K8OIJ6EdNqvrXwbJKOH0ziNKX86+u7W0WocjdkyMZtVAa0zJp45JBu4l5Y4g85Lnu2HLuBm1UQOhqDW/FLT8/EDRuKyUmq85h4cZkqeWjx8HjwpWJXtsN7FobDJMxsT3MHKA7fuJAB6eY43Z+TA6HwOktRZPV2X1DdyEdjL1sRUhyVRlRrXSQGrO6GFk4MjAecDZocQw7hajiuAOMw2GzletqbU7c3mrENi9qY5BvwnIYduyZziPkDGjcBgZy7OcCDuumfBl0v5PQUW5LOR5eHKy5uPUsd0NybbsjQySXtAzk85gDCzk5C0AcvRW0jvcD8try9UzlbW+PvQsq2WfBl/Jw1YLVuFzAXdrHWlkjDmPBG7SA4Fp5Qd1zcfMrrHDaIgs6MbZ8aGQgGQmx9Rlu5BR3PbSV4X+bJIPN2aQehdsCQF2YMHqjh7hYKWnGya5nmmkmtXNV550EzSQ0NDTHWkby9D5oawDbpvuV1reE1lxDpux+oIjoSOF7bEGS0nqJ09l0g3HI5slNjeQhxJB5gSB09K17rCoaS4n38trLhPQx2sPKrC5rH5uW9eNCOs+1JXfXEQfHygxPj7R7HNHLuQd29wFascUdc5bNQ4mlqMY51riRf04LPiMEpiox0nyNY1pbsXNc3cOO5325uZu7TosPg36eoYnA18Zl87icphrVu5Bna1pjrssto72TKZI3Mf2h2JBZt5rdttlyad8HTTumn42SDJZq1LR1FPqZsly0yV8tuWB0LxI4s3czZxO2/NzffbdFLVDIMxr/iZpfSPFDPya7ORHD/LitFWlxFVgycIZBM4WHNYCHcs/IDF2e3Lud99hNcRtccQI8lxwu4fWJw9HQsFe7j6DMZXmbPvj47Ekcr3tLiwuDtuXZwLz5xADRqOa4EYDO6a1/hLFzJMqa0tG5kHxyxiSJ5iij2hJYQ0bQt+6DupPXu27OW4MYTMxcRY5rV9o11A2vkuzkYOxa2qKwMO7DynkG/nc3nfm6JaRn2I19qfR+tKFTVOsIshhczpK3n5LVjHxQtxUsBhLyzswC6HlmJ5XlzvMHnHcqH4R8VtZz8TcVhsxkszm8Bn8LayNG9nMLVxry+F0RD4GQuLuyc2X7mZoePNO53K1rO8FdO6lu0Z8kbdmKrgrWnTVdI0RzVbAjEnPs3m59omgFpG256d20RprwesXpzUmCzsmp9TZnI4avLSqOyl2ORgrSM5DCWNiaNhsx3MAHksbzOcBslpGPxZniFqPwPMnr/Na6fZyVrTcl3xAYag+oQ0F2z2Phdzl7W7PB83zzytGwKl9QcT9fal13l9NaSiztKlpuhQEsunsbjbJmsWK4mHai3NGGxhpaA2Ju5If5w2AWvV+C2ErcFTwwbayBwBxbsT4yZGeNdk5paXc3Jy82x7+Xb8y6Oo+AeJzWoGZzHZ/UOlMu6nHj7dvA3GQOvQxgiMTB0bmlzdzs9oa4bkA7bKaMjL9QcSOJuIuaRu61yE/DTBTYqL4QvUsXBfrMyfbuY+O28l/YROZ2Za4EAF5Bk6L0jlzviLpHd2D/8AxKz7XPAbHcQa8FLJan1RHhxRix9vFV8kBXvxMJP8dzMc4udvs57XNc4bAnotAyrQzDXGtADRXeAB6ByleuHExVF1jxSmhf8AYjT39XV/1TVOKD0L/sRp7+rq/wCqamP11pvLahs4CjqHFXc7WjM0+Mr3YpLMTA4NL3RB3M1oc5oJI23IHpXDjfuVfGSfFOIi62TtvoY23airSXJIYnyNrw7c8pAJDG7+k7bD+leSMy4G0tLady3EPTundSXc7bq6glvZKtc5nDHTWWtkFeN5aA5gA/CcQdwSD0WrKicGH2cpoanqHK6Pq6J1Jnd72VxteMCTtj5odK7la5zyxrN+Ybju3O26vaAiIgIiICpHGrGZnM8MM5T0/qeHRmYlZGK+csODWVSJWEkk+toLf+ZXdZh4THkd8R2qPjA8c8kOzh8f8Q37bl7ePk5duv3fJ+jdBpVVrm1oQ94leGAOePvjt3rlXBR7PxKv2O/Y9m3k37+Xbp/gudAREQUK61+kcxlZbFazNjshY8ajsVa75+zcWMY5j2saXDq3mDtttiQSNhvweXeJ9WR+i7X2a0RF3R2imYjTpvPxt9JavHvZ35d4n1ZH6LtfZp5d4n1ZH6LtfZrREV1jC4Jz/BsZ35d4n1ZH6LtfZp5d4n1ZH6LtfZrRETWMLgnP8Gxnfl3ifVkfou19mnl3ifVkfou19mtERNYwuCc/wbGd+XeJ9WR+i7X2aeXeJ9WR+i7X2a0RE1jC4Jz/AAbGXYbivpjUVBl7FXp8nSeXNbZp0bEsbi0kOAc2Mg7EEH84Xd8u8T6sj9F2vs10fBpyul8zwixlvRunrWlsA6xaEOMub9pG8WJBI47ud908OcOvcVqSaxhcE5/g2M78u8T6sj9F2vs08u8T6sj9F2vs1oiJrGFwTn+DYzvy7xPqyP0Xa+zTy7xPqyP0Xa+zWiImsYXBOf4NjO/LvE+rI/Rdr7NPLvE+rI/Rdr7NaIiaxhcE5/g2M78u8T6sj9F2vs1+LGofKCpNQw9O9YuWGOiY6alNBDFuNud8j2BoA3326k7dAStHRNYojbFM3+P4gvD+XvhwaL496Bs3LFzVGVzHDAu7Co7FSmCvWgJ2jgswx7dWjZokcCHdPO5jyiG/g4Is5p3UnEbXuHwcuqXYXCQY84WnKGW7L7NqNzTHzDl2aytK525B6NAB3O39VbtKvkac9S3BFaqzsMcsEzA9kjCNi1zT0II6EFZvwi8HXRnA3P6ryejqk+Mi1G6u+zju1560Doe02MII5mhxmeSC4gdA0NA2XDMzM3llz5PjdjdO+QMOcwmcxmQ1f2ccFUUXTeIzP7ICKy5m4iIdKBuenmv/AASoDiNq1nFLP5rhTpHVt/Ses8aauQvXYaMo5KrXwyOZFN0ZzObLGOhd0LgQRvtsyKAiIgIiICIiAqRxqyeZw3DDOXNP6Yh1nmImRmvg7DQ5lomVgIIPqaS7/lV3VG43Y/LZThbnq2C1TBonKvjjMOesvDI6m0rC5ziegBaHN/5kF0quc6tCXsETywFzB96du5cq62OmbYx9WVlhlpj4mubPG4ObICBs4EdCD37/AJ12UBERAREQEREBERAREQERfiaaOvE+WV7YomNLnvedmtA6kk+gIKdwgta2uaEpy8QqdKhqkyzieDHkGEMErhERs5w3MfIT17ye5XRZr4O+LoYfhVjauN1q/iFTbPZczPvl7QzkzvJbzczt+Qks7/vfQtKQEREBERAREQEREBERAREQEREBERAREQF0M9gcbqjD3MTl6NfJ4y5GYrFS1GJI5WHvDmnoV30QZhW0fqfh3mtB4DQNHB1OGlCGWpk6Fl0vjULduaOSJ+55jzAgh3UmQk797bboniJpriRjrF7TGbp5urWsSVJpKknN2crDs5rh3g9Nxv3ggjcEFWJUHX2gMzY09aj4d5ejobPWMizJWLjcbHNFdeNg9s7OhdzgNBeDzeaOqC/IqVheLeBzPE3NcP2Pts1NiKkV2eOanJHDLC8N/jInkcrmguDT179wN9jtA8LPCV0Jxm1rqrTOlMm7I29PFna2Whvi9tp3Dn13hxMjGuHKXbAEkFpc1wcQ1NERAREQEREBFlvGPwkdGcC85pPFaoszQ2dSXBUrui7MR1m8zWusWHve0RwtLxu7qdgdgdjtO664p0dC6k0ngpcXl8rkNSXDVrtxlJ0zIGt2Mk0zx0Yxgc0nrvsSQCASAkOInEXT3CnSV3Uup8gzGYioBzzOaXOc4nZrGtaCXOJ6AAKFZQ1VqnXDrc2Qw8/C63hxG3EyUXut25pfunSl+wawM2Abt1Ejg5u4BXJoXQGcwl/VVjVGq59YQ5bJeN0aVqrHHBjYWH+KijaB1I2YS7pu5ocACXF17QRemdMYnRmCp4XBY6vicTTZ2denUjDI42/mA9JO5J7ySSepUoiICIiAiIgIiICIiAiIgIiICIiAi62SutxuOtW3NLmwRPlLR6Q0E7f4LO8fpahqXHVMnnK7crkLULJpH2CXsYXNB5Y2k7MYN9gAB6zuSSenCwYxImqqbRn9YW29pqLOfi50x8hUfmQnxc6Y+QqPzIXvq+FxzlH3LsaMizn4udMfIVH5kJ8XOmPkKj8yE1fC45yj7jY0ZFnPxc6Y+QqPzIT4udMfIVH5kJq+FxzlH3GxlHh88R9b6F4VQ0NA4bLWMtnHyVrmZxlB8/wfTa3+M/jWHeKR5ewMcQfNEpBa5rSv5l+Dxxcv+D7xkweqeynbBWl7DI1Ni101V/SRux23O3nN36czWn0L+xfxc6Y+QqPzIXHNww0lYG0uncdKPU+u0pq+FxzlH3GxoGMyVXNY2pkKM7LVK3CyeCeI7tkjc0Oa4H0ggg/pXaWcM4baWjY1jMBQaxo2DWwgAD1L78XOmPkKj8yE1fC45yj7jY0ZFnPxc6Y+QqPzIT4udMfIVH5kJq+FxzlH3Gxoy4rVmGlWlsWJWQQQsMkksjg1rGgbkknuAHpWffFzpj5Co/MhPi50x8hUfmQmr4XHOUfcbH8hfCk4zW/CF425jPwCWfGNf4hh4GsJIqxuIZs3bfd5LpCPQXkepf0J/g4tVazucJruk9WaZyWIr6cfG3GZTIRTx+OwzGR5jAkGxMXKBuw7cskY5QRu/bIeF+ka42i05joh/uV2j/suX4udMfIVH5kJq+FxzlH3GxoyLOfi50x8hUfmQnxc6Y+QqPzITV8LjnKPuNjRkWc/Fzpj5Co/MhPi50x8hUfmQmr4XHOUfcbGjIs5+LnTHyFR+ZCfFzpj5Co/MhNXwuOco+42NGRZvNo3HYmtLZwtduIvxNL4Zqu7BzDrs5o6OadtiCD0/wCqvGncr8O6fxmS5QzxyrFY5R3DnYHbf4rxxcGKI0qZvHwt9ZS25IIiLlQREQEREBERAREQReqv9mMx/wDDm/8AAqvaZ/2cxX/xIv8AwCsOqv8AZjMf/Dm/8Cq9pn/ZzFf/ABIv/AL6OD+zPx+jXuUuHwhdA2tXV9M1s463mLFx1CGOvSsPiknZv2jGzCPs3Fmx5tnHl2PNtsuZ/HzQMeqvJ52oYhkvGxQ5uwm8W8Z327Dxjk7HtN+nJz82/TbfovOPD8TYbUGh9G6sGSwGmNNapnmwdi7p25DLesvknZWiltFpgG5ncd2OPaeb3EldvhdwupY7DY/h9rjTHEa9lq+RdHPPVyF84Ky3xgyx292zCBrfuXluwcHA+aSsRVMst9t+ENw+oZmxi59QCO3WvfBtk+J2DDWs8/II5pRHyREuIAL3AO9BK7es+OOiOH+XOLzmcFW8yITzRxVZrArRnfZ8zo2OELTsdjIWjYbrE9VaMz1jgNx8oRYLIy5DJanvWaFVlSQy2mF1cskiaBu8HlOzm7jzTt3Lg1Bo92l+KXESTU2n+IWao6htx38ba0bduivYjNdkTq07K8rGMe0sIDpdgWkecANk0pG5Z3jnonTucgw1rMumylinFkIKlClYuPmrSuc1krBDG/mbux25G+w2J2BBPwcdtDeWrdJuznZZx1k0mxS1J2RPsDfeJs7mCJz+h80O3/MqjoHQDNIcfJxjsNbp6do6GxuKo2JmPexgjs2CYBK7fmc1vZkjmJ25SfQsh1vR1hqHJCzm8RrvJ6jxWtK1/sKkE3wNWxkN5ro3wMYRHO7sQ09A+UOLtwACrNUwN40Hx6xeuOJOrtHspXatrCXvE4ZnUbPZ2A2Fr5HOkMQjj2c5zWtc7zg0ObuHBSOE496C1HqSHBY/UMU9+eV8FdxgmZXsyN35mQzuYIpXDY9GOceh9SoNChl8bxL4u6alxGYrHWL2WMTnq9KSSiwHHMhJkmaCI3NkiI2dsTu3bfdVDgnoPFSQaG03qXSHEatqHT7oHym/kL0mErWqrN2TRudN2Do3OZ5jYwducDlA3S8j1avP2nvCWl1VqTXlmtJXx+k9LCSFwtYLIvtzPbHGe1LmsDWtD5ADEGOk5Wl3mggr0CsS0Hp7KU8BxyjsY25BJkdRZGekySB7TajdRrta+MEee0ua4At3BII9C1NxM43wgtL43TemJNRZuvJm8tha+YbDhsfcmbYikbuZYIhG6Xk33OzhzNGxcApjNcc9EYHTWGz9nN9ticywyUJ6NSe2Z2gAkhkTHOAG433A29Oyy/gZpXNYjW3Dmxfw9+lDU4WUsdYlsVXxthtNlhLoHkgcsgAJLD5w2PRVDTFDV2m9BcPcRk8drLG6TE2bdkq+mKs7Mh25vyOqMk7MCaKF0bnuDmbA+buQ0hY0pG25rjFFPl+Fz9M2KOWwOr8hNXfdAc49kypNMDGQ4crueIA8wO3nDYHu05eQ9CaY1HpTRPCy1Z0pqD/6Y1nlHX6Dq7prkVez42I5gAT2rB4xGXPYXDq47nYr14tUzfxFKocZdH5XW82kqeXNnOwzSV5IYqsxibKxhe+LtuTsudrQSWc2427lzVOLek72mdN6hgyvPh9RWYaeLs+LSjxiWUkRt5SzmbuWnq4ADbqQskxYy+n+PXi+isLqrH4jKZezLqenlseW4hw7N3/rqtg90j3tZ5jHEO5iS1pG6pOm6moKvDbgzoOXRupGZfTGp8f8K2XYyQVIYoZZAZWzbcsjCCHBzNwB90W+maUjb7nhOcNMfYfFZ1M2AR25aEk76VkQR2Y3Oa+F8vZ8jZN2O2YXAuGxaCHAmRh49aEl01l88/PCrjMPYhq5F9ypPXkqSSvYyPtYpGNkYHGRuzi3l2JO+wJGMN0ZnviegpHBZHxwcTvhA1/E5O08W+GjJ2/Ltv2fZ+fz93L132X3jJo3PZTN8aX0sFkbcWRZpLxR0FSR4smG6503Z7Dz+RuxdtvyjbfYKaUjUZPCh4axOuMfnrLLFNoksVnYi6J4ott+2MXY84i269rtydR53UKY1bx10PoerjLOWzfJXyVbx2rNUqT2mSQbA9qTCx4azYg8zth171WrWn8hJ4QGtMh8G2XY6zoupUitdg4wyzCxbLomu22c4BzSWg77OHTqFkWAx+rsfpDhzgc9i9cwabh0ZWijx+mYZoJ35QbtfDbezlfC1rOz5Q9zI9y7mPTZW8j0PqTjZorSYwXwjm2752s+3ixUrzWjdiaIyTEImOLztKwho6kHcAgHbsUeLuk8hpnP6gjyhjxWA7QZOSzVmgfVLImyuDo3sD9+R7XDZp336bnosL4M6PzlPIeD8clgMlUfgdN5ijedbpvaKc4NaNrXOI2bzBj+Q7+e3ct3C5uNWjcha464nTVCNr9P8SWV351u/VgxkjZZHf0TQujhP/CE0ptcelJZ2WcY+aMkxyQl7SWlp2Ldx0PUfpXb4c/ye6X/AKrq/qmrguf6nP8A/pu/7Ln4c/ye6X/qur+qatYv7P8AMfKWvcsSIi+cyIiICIiAiIgIiII3UsbptOZWNgLnuqStAHpJYVW9LvEmmcQ5p3a6nCQR6RyBXZVCfQU1eVww+bs4mo4lwpiGKWKMnv5OZu7Rv97vsPQAOi7cDEpimaKpt7/9ZqPCyi43weeH2J1NHnq+nx8IxWjdi7W5YlgisEl3asgfIYmP3JPM1oIPULRlH+RWc9rJvcIfqTyKzntZN7hD9S947qPCuMp6FuaQRR/kVnPayb3CH6k8is57WTe4Q/Ul8LzI9ehbmkEUf5FZz2sm9wh+pPIrOe1k3uEP1JfC8yPXoW5pBcVqrDerTVrETJ68zDHJFI3dr2kbEEekELqeRWc9rJvcIfqTyKzntZN7hD9SXwvMj16FuamDwduFrSCOHmmQR1BGKh/ZWhqP8is57WTe4Q/UnkVnPayb3CH6k9lH/cZT0S0b0gip/EPHah0ZoDU2oINTPsT4nGWb8cMlGINe6KJzw07DfYluy6PCIaj4jcLdJ6ptakdUs5nGV78kENGIsjdJGHFrSRvsN/Sl8LzI9ei25r8s9f4PHC+R7nv4e6Zc5x3LjioSSf7quXkVnPayb3CH6k8is57WTe4Q/Unsp/7jKeiWje7VOnBj6kFWrCyvWgY2KKGJoa1jGjYNAHcAABsuZR/kVnPayb3CH6k8is57WTe4Q/Ul8LzI9ei25pBFH+RWc9rJvcIfqTyKzntZN7hD9SXwvMj16FuaQRR/kVnPayb3CH6k8is57WTe4Q/Ul8LzI9ehbmkFXqHD/T+N1jktVwY1g1FkImwWMhI98j+zaGgMZzEiNvmNJawAEjc7nqpHyKzntZN7hD9SeRWc9rJvcIfqS+FxxlPRLRvdnIPbHQsvcQ1rYnEk+gbFdrh9E6HQWmo3gtezGVmuB9BETVHx6Bnt7xZjOWcpSd0kp9hFFHMPwZOVu5b62ggEEg7gkK4LxxsSnQ0KZvtv/rr7rCIi4WRERAREQEREBERAREQEREBERAREQEREBERBRuOv8iPEL+zuR/y0iiPBd/m4cMv7O0f1LVL8df5EeIX9ncj/AJaRRHgu/wA3Dhl/Z2j+pag1BERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQUbjr/IjxC/s7kf8tIojwXf5uHDL+ztH9S1S/HX+RHiF/Z3I/wCWkUR4Lv8ANw4Zf2do/qWoNQREQEREBERAREQEREBERAREQEREBERAREQEREBERAREQEREBERARdLMZqhgKEl3JW4aVSP7qWZ4aNz3AesnuAHUnuWd3uPNBspbjsLkL0YOwnl5K7XfnAcef/q0LrweyY/aP2qZn5ZrZqKLIfj7sey8vvzP2U+Pux7Ly+/M/ZXX+lds4PWOpZ4g/hQ+CcunuIGP4l0mPfj9QNZTvk9RFbijDY+voD4mDYD0xPPpUf8AwYHCO7qbixc13K6SHD6aicyLYkNntzRPiDdu4hsT5SfSC5nrXrXjfqCpxx4YZzRuU05LWiyEQ7G220x7q0zSHRygbDflcBuNxuNxuN11PB/yNTwf+F2L0djdPSXjWL5rV82GROtzvO7pC3Y7dOVoG52a1o3OyfpXbOD1jqWeo0WQ/H3Y9l5ffmfsp8fdj2Xl9+Z+yn6V2zg9Y6lmvIsto8eab5Wtv4PIU4ydjLC5k7W/nIBDtv6AVoeEz2P1Jj2XcZbiu1XHYSRO32PpaR3gj0g7ELkxuyY/Z9uLTMR6ZlnfREXIgiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiIC4rVqKlWmsTyNighYZJJHHYNaBuSf6AuVUfjVZfW4a5UMO3bvr1X/nZLPHG8fpa8j9K98DD77Fow+KYjOVjbLI9Saqta3yYyNnnjrN3NOo8bdgw+kj8Nw6k+jfYdB1jURfpuHh04VMUURaIYmbiIss4r62z1HVeD0vp2O82zdrT3rFjGwV5rDY43MaGsbYe2PqX9SdyABsOpImJiRhU6Uo1NFhp1XxDZW0zjcjNLgruQ1BJj23LVSs6axT8Vkka90bHvYyQOaR5p23YCQQS0/bfEfVGChzmmvhGLI52PUVPB0cxarMaGMswslEkkbA1rnMaXjoACeXp378+t0+MxMdbXsraGZKnJkJKDbUDr0cbZn1RIDK1jiQ15bvuGktcAe47H1LsrIdBYrKYfjlqSvls3Jn7PwBRc23LWjgdy9vP5pbGA07Hc77DoQPRudeXvhVziUzMxbbKC7uB1Hd0dlRlKHPJsNrNNp821GPvSO7nH3ru8Hp3FwPSRbropxKZori8SsTZ6ex9+vlaFa7VkE1axG2WKQffNcNwf+hXYVC4IWXTcP68Tvua1qzAz/hEz+UfoBA/Qr6vzLtGF3ONXh7pmG58RERc6CIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAoHXennaq0hlMXGWieeHeAu7hK0h0ZP5g9rVPIt0Vzh1xXT4xtHlaCUzRNc6N8T+50cg2cxw6FpHoIO4P9Cr2byWrK2QfHicBi8hSAHLPay767yduoLBXeB1/3v+i9AcQ+FkmXsy5bBdlHkJPOsVZXFsdg7AcwOx5X7D1bO6b7fdLJb1a9iZTFkcVkKEgOxE1Z5b+h7QWO/Q4r9E7P2zC7ZRE0VWn3xsv6+7mW3KWc1r3ptpPB/n31BL+6LrZXQ0/ECGhez0T9MZ/GzPNK7gMkZZYmOaA4c74Wgh3cWFhHmg7+q4fCtb8J/wA076k+Fa34T/mnfUuucLSi1czMfx0TRncrrOG1MxaeFnJ5TITYS6+/DYuWBJLLI5kjCJCW9W7SO2DeXbYbdBsurmuEGDz3lEbUl3tM1ar3nyxTBj6s8EbGRSQOA3YQGA7nfrv6DsrZ8K1vwn/NO+pPhWt+E/5p31Kzg0TFpj/Wt8jRncpFDh7d0TkredxFq7qvOXIIaU3lBkmwt7FjnuBDo4HbHd+23Lse/od95EZnXmzt9KYMHbptqCXqfdP6VZvhWt+E/wCad9SfCtb8J/zTvqUjC0dlEzEfx9YNGdyEw+U1fYyMMeT09iaNE79pYrZmSeRnQ7bMNZgO52H3Q23367bKx2Jm14HyuDnBg35WDdx/MB6SfQFyUYbeWlbHj8bfvSE7bQVXlo/pcQGgfnJC1Th9woloXIMvqBsZtwnnrUI3c7IXeh73dznj0Aea09fOPKW8vaO14XY6JnEqvO7Zf0+a6O9beHWnpdL6NxtCwALYa6awBt0lkcXvHT1FxH6FZERfneJXOLXNdXjM3PEREXmCIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiD/2Q==",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from IPython.display import Image\n",
+    "\n",
+    "Image(app.get_graph().draw_mermaid_png())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "678c0200-32df-4faf-bc54-a4dd470f199c",
+   "metadata": {},
+   "source": [
+    "애플리케이션을 실행할 때 그래프를 스트리밍하여 실행 단계의 순서를 확인할 수 있습니다. 아래에서는 각 단계의 이름을 간단히 출력합니다.\n",
+    "\n",
+    "그래프에 루프가 있기 때문에 실행 시 [recursion_limit](https://langchain-ai.github.io/langgraph/reference/errors/#langgraph.errors.GraphRecursionError)을 지정하면 도움이 됩니다. 한도를 초과하면 해당 오류가 발생합니다.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "b5e32a3c-f43e-4e18-a32d-466403afa844",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['generate_summary']\n",
+      "['collect_summaries']\n",
+      "['collapse_summaries']\n",
+      "['collapse_summaries']\n",
+      "['generate_final_summary']\n"
+     ]
+    }
+   ],
+   "source": [
+    "async for step in app.astream(\n",
+    "    {\"contents\": [doc.page_content for doc in split_docs]},\n",
+    "    {\"recursion_limit\": 10},\n",
+    "):\n",
+    "    print(list(step.keys()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "b0b28b30-d12b-4a30-a0e2-f897adab68c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'generate_final_summary': {'final_summary': 'The consolidated summary of the main themes from the provided documents is as follows:\\n\\n1. **Integration of Large Language Models (LLMs) in Autonomous Agents**: The documents explore the evolving role of LLMs in autonomous systems, emphasizing their enhanced reasoning and acting capabilities through methodologies that incorporate structured planning, memory systems, and tool use.\\n\\n2. **Core Components of Autonomous Agents**:\\n   - **Planning**: Techniques like task decomposition (e.g., Chain of Thought) and external classical planners are utilized to facilitate long-term planning by breaking down complex tasks.\\n   - **Memory**: The memory system is divided into short-term (in-context learning) and long-term memory, with parallels drawn between human memory and machine learning to improve agent performance.\\n   - **Tool Use**: Agents utilize external APIs and algorithms to enhance problem-solving abilities, exemplified by frameworks like HuggingGPT that manage task workflows.\\n\\n3. **Neuro-Symbolic Architectures**: The integration of MRKL (Modular Reasoning, Knowledge, and Language) systems combines neural and symbolic expert modules with LLMs, addressing challenges in tasks such as verbal math problem-solving.\\n\\n4. **Specialized Applications**: Case studies, such as ChemCrow and projects in anticancer drug discovery, demonstrate the advantages of LLMs augmented with expert tools in specialized domains.\\n\\n5. **Challenges and Limitations**: The documents highlight challenges such as hallucination in model outputs and the finite context length of LLMs, which affects their ability to incorporate historical information and perform self-reflection. Techniques like Chain of Hindsight and Algorithm Distillation are discussed to enhance model performance through iterative learning.\\n\\n6. **Structured Software Development**: A systematic approach to creating Python software projects is emphasized, focusing on defining core components, managing dependencies, and adhering to best practices for documentation.\\n\\nOverall, the integration of structured planning, memory systems, and advanced tool use aims to enhance the capabilities of LLM-powered autonomous agents while addressing the challenges and limitations these technologies face in real-world applications.'}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9e33d11-7a2a-4693-8c87-88b88eebc896",
+   "metadata": {},
+   "source": [
+    "해당 [LangSmith 트레이스](https://smith.langchain.com/public/9d7b1d50-e1d6-44c9-9ab2-eabef621c883/r)에서는 각 노드별로 그룹화된 개별 LLM 호출을 확인할 수 있습니다.\n",
+    "\n",
+    "### 더 깊이 들어가기\n",
+    "\n",
+    "**커스터마이징**\n",
+    "\n",
+    "* 위에서 본 것처럼 맵 단계와 리듀스 단계에서 사용할 LLM과 프롬프트를 자유롭게 구성할 수 있습니다.\n",
+    "\n",
+    "**실제 사용 사례**\n",
+    "\n",
+    "* [이 블로그 글](https://blog.langchain.dev/llms-to-improve-documentation/)은 사용자 상호작용(문서 질문)을 분석하는 사례 연구를 소개합니다.\n",
+    "* 이 블로그 글과 관련된 [저장소](https://github.com/mendableai/QA_clustering)는 요약 수단으로 클러스터링을 소개합니다.\n",
+    "* 이는 `stuff`나 `map-reduce` 방식 외에 고려해 볼 수 있는 또 다른 경로를 제시합니다.\n",
+    "\n",
+    "![Image description](../../static/img/summarization_use_case_3.png)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8680f94-c872-4d36-92e5-1462ffeb577d",
+   "metadata": {},
+   "source": [
+    "## 다음 단계\n",
+    "\n",
+    "다음 내용을 자세히 다루는 [How-to 가이드](/docs/how_to)를 참고해 보세요: \n",
+    "\n",
+    "- [반복 정제](/docs/how_to/summarize_refine)와 같은 다른 요약 전략\n",
+    "- 내장 [문서 로더](/docs/how_to/#document-loaders)와 [텍스트 분할기](/docs/how_to/#text-splitters)\n",
+    "- 다양한 문서 결합 체인을 [RAG 애플리케이션](/docs/tutorials/rag/)에 통합하기\n",
+    "- 검색을 [챗봇](/docs/how_to/chatbots_retrieval/)에 통합하기\n",
+    "\n",
+    "그 밖의 여러 개념도 함께 확인할 수 있습니다.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add Korean-translated versions of the agents and summarization tutorial notebooks for Korean-speaking users.

## Testing
- `pre-commit run --files docs/docs/tutorials/summarization_ko.ipynb`


------
https://chatgpt.com/codex/tasks/task_e_68a16b07bd648332ac27dd49a54e4ee9